### PR TITLE
🐛 env values need to be string

### DIFF
--- a/exemples/kubernetes/crowdsec/values.yml
+++ b/exemples/kubernetes/crowdsec/values.yml
@@ -22,4 +22,4 @@ lapi:
       value: "k8s linux test"
     # If it's a test, we don't want to share signals with CrowdSec so disable the Online API.
     - name: DISABLE_ONLINE_API
-      value: true
+      value: "true"


### PR DESCRIPTION
❯ helm -n crowdsec upgrade --install crowdsec crowdsec/crowdsec --values=/opt/helm/values.yml
> Error: UPGRADE FAILED: failed to create resource: Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal bool into Go struct field EnvVar.spec.template.spec.containers.env.value of type string