### PR TITLE
✨ Add Traefik Crowdsec Plugin Basic User Agent

### DIFF
--- a/bouncer.go
+++ b/bouncer.go
@@ -552,7 +552,7 @@ func crowdsecQuery(bouncer *Bouncer, stringURL string, isPost bool) ([]byte, err
 		req, _ = http.NewRequest(http.MethodGet, stringURL, nil)
 	}
 	req.Header.Add(bouncer.crowdsecHeader, bouncer.crowdsecKey)
-	req.Header.Add("User-Agent", "Traefik Crowdsec Plugin")
+	req.Header.Add("User-Agent", "Crowdsec bouncer Traefik Plugin")
 
 	res, err := bouncer.httpClient.Do(req)
 	if err != nil {

--- a/bouncer.go
+++ b/bouncer.go
@@ -552,6 +552,8 @@ func crowdsecQuery(bouncer *Bouncer, stringURL string, isPost bool) ([]byte, err
 		req, _ = http.NewRequest(http.MethodGet, stringURL, nil)
 	}
 	req.Header.Add(bouncer.crowdsecHeader, bouncer.crowdsecKey)
+	req.Header.Add("User-Agent", "Traefik Crowdsec Plugin")
+
 	res, err := bouncer.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("crowdsecQuery:unreachable url:%s %w", stringURL, err)


### PR DESCRIPTION
Following the [rfc](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) the idea would be to have something like:

"User-Agent": "Traefik Crowdsec Plugin / <plugin-version>"

We'll look if you can get this information from Traefik context
