### PR TITLE
🐛 fix(user-agent) add version in ua to reduce warning logs from crowd…

### DIFF
--- a/bouncer.go
+++ b/bouncer.go
@@ -552,7 +552,7 @@ func crowdsecQuery(bouncer *Bouncer, stringURL string, isPost bool) ([]byte, err
 		req, _ = http.NewRequest(http.MethodGet, stringURL, nil)
 	}
 	req.Header.Add(bouncer.crowdsecHeader, bouncer.crowdsecKey)
-	req.Header.Add("User-Agent", "Crowdsec bouncer Traefik Plugin")
+	req.Header.Add("User-Agent", "Crowdsec bouncer Traefik Plugin/1.3.5")
 
 	res, err := bouncer.httpClient.Do(req)
 	if err != nil {

--- a/bouncer.go
+++ b/bouncer.go
@@ -552,7 +552,7 @@ func crowdsecQuery(bouncer *Bouncer, stringURL string, isPost bool) ([]byte, err
 		req, _ = http.NewRequest(http.MethodGet, stringURL, nil)
 	}
 	req.Header.Add(bouncer.crowdsecHeader, bouncer.crowdsecKey)
-	req.Header.Add("User-Agent", "Crowdsec bouncer Traefik Plugin/1.3.5")
+	req.Header.Add("User-Agent", "Crowdsec bouncer Traefik Plugin/1.X.X")
 
 	res, err := bouncer.httpClient.Do(req)
 	if err != nil {

--- a/bouncer.go
+++ b/bouncer.go
@@ -552,7 +552,7 @@ func crowdsecQuery(bouncer *Bouncer, stringURL string, isPost bool) ([]byte, err
 		req, _ = http.NewRequest(http.MethodGet, stringURL, nil)
 	}
 	req.Header.Add(bouncer.crowdsecHeader, bouncer.crowdsecKey)
-	req.Header.Add("User-Agent", "Crowdsec bouncer Traefik Plugin/1.X.X")
+	req.Header.Add("User-Agent", "Crowdsec-bouncer-Traefik-Plugin/1.X.X")
 
 	res, err := bouncer.httpClient.Do(req)
 	if err != nil {

--- a/bouncer.go
+++ b/bouncer.go
@@ -552,7 +552,7 @@ func crowdsecQuery(bouncer *Bouncer, stringURL string, isPost bool) ([]byte, err
 		req, _ = http.NewRequest(http.MethodGet, stringURL, nil)
 	}
 	req.Header.Add(bouncer.crowdsecHeader, bouncer.crowdsecKey)
-	req.Header.Add("User-Agent", "Crowdsec-bouncer-Traefik-Plugin/1.X.X")
+	req.Header.Add("User-Agent", "Crowdsec-Bouncer-Traefik-Plugin/1.X.X")
 
 	res, err := bouncer.httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
…sec LAPI

Still didn't found a way to get the version of the plugin programatically but, i added manually the version so Crowdsec does'nt warn about the user agent 