### PR TITLE
Add AppSec Path Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,10 @@ Only one instance of the plugin is *possible*.
   - string
   - default: "crowdsec:7422"
   - Crowdsec Appsec Server available on which host and port. The scheme will be handled by the CrowdsecLapiScheme var.
+- CrowdsecAppsecPath
+  - string
+  - default: "/"
+  - Crowdsec Appsec Server availble on this path. Will be appended to CrowdsecAppsecHost.
 - CrowdsecAppsecFailureBlock
   - bool
   - default: true
@@ -493,6 +497,7 @@ http:
           crowdsecMode: live
           crowdsecAppsecEnabled: false
           crowdsecAppsecHost: crowdsec:7422
+          crowdsecAppsecPath: "/"
           crowdsecAppsecFailureBlock: true
           crowdsecAppsecUnreachableBlock: true
           crowdsecLapiKey: privateKey-foo

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Only one instance of the plugin is *possible*.
 - CrowdsecLapiPath
   - string
   - default: "/"
-  - Crowdsec Appsec Server available on this path. Will be appended to CrowdsecLapiHost. Need to finish with "/".
+  - Crowdsec LAPI Server available on this path. Will be appended to CrowdsecLapiHost. Need to finish with "/".
 - CrowdsecLapiKey
   - string
   - default: ""

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Only one instance of the plugin is *possible*.
 - CrowdsecAppsecPath
   - string
   - default: "/"
-  - Crowdsec Appsec Server availble on this path. Will be appended to CrowdsecAppsecHost.
+  - Crowdsec Appsec Server available on this path. Will be appended to CrowdsecAppsecHost. Need to finish with "/".
 - CrowdsecAppsecFailureBlock
   - bool
   - default: true
@@ -348,6 +348,10 @@ Only one instance of the plugin is *possible*.
   - string
   - default: "crowdsec:8080"
   - Crowdsec LAPI available on which host and port.
+- CrowdsecLapiPath
+  - string
+  - default: "/"
+  - Crowdsec Appsec Server available on this path. Will be appended to CrowdsecLapiHost. Need to finish with "/".
 - CrowdsecLapiKey
   - string
   - default: ""
@@ -502,8 +506,9 @@ http:
           crowdsecAppsecUnreachableBlock: true
           crowdsecLapiKey: privateKey-foo
           crowdsecLapiKeyFile: /etc/traefik/cs-privateKey-foo
-          crowdsecLapiHost: crowdsec:8080
           crowdsecLapiScheme: http
+          crowdsecLapiHost: crowdsec:8080
+          crowdsecLapiPath: "/"
           crowdsecLapiTLSInsecureVerify: false
           crowdsecCapiMachineId: login
           crowdsecCapiPassword: password

--- a/bouncer.go
+++ b/bouncer.go
@@ -67,6 +67,7 @@ type Bouncer struct {
 	appsecUnreachableBlock  bool
 	crowdsecScheme          string
 	crowdsecHost            string
+	crowdsecPath            string
 	crowdsecKey             string
 	crowdsecMode            string
 	crowdsecMachineID       string
@@ -106,8 +107,10 @@ func New(_ context.Context, next http.Handler, config *configuration.Config, nam
 	if config.CrowdsecMode == configuration.AloneMode {
 		config.CrowdsecCapiMachineID, _ = configuration.GetVariable(config, "CrowdsecCapiMachineID")
 		config.CrowdsecCapiPassword, _ = configuration.GetVariable(config, "CrowdsecCapiPassword")
+		config.CrowdsecLapiScheme = configuration.HTTPS
 		config.CrowdsecLapiHost = crowdsecCapiHost
-		config.CrowdsecLapiScheme = "https"
+		config.CrowdsecLapiPath = "/"
+		config.CrowdsecAppsecEnabled = false
 		config.UpdateIntervalSeconds = 7200 // 2 hours
 		crowdsecStreamRoute = crowdsecCapiStreamRoute
 		crowdsecHeader = crowdsecCapiHeader
@@ -153,6 +156,7 @@ func New(_ context.Context, next http.Handler, config *configuration.Config, nam
 		appsecUnreachableBlock:  config.CrowdsecAppsecUnreachableBlock,
 		crowdsecScheme:          config.CrowdsecLapiScheme,
 		crowdsecHost:            config.CrowdsecLapiHost,
+		crowdsecPath:            config.CrowdsecLapiPath,
 		crowdsecKey:             config.CrowdsecLapiKey,
 		crowdsecMachineID:       config.CrowdsecCapiMachineID,
 		crowdsecPassword:        config.CrowdsecCapiPassword,
@@ -410,7 +414,7 @@ func handleNoStreamCache(bouncer *Bouncer, remoteIP string) (string, error) {
 	routeURL := url.URL{
 		Scheme:   bouncer.crowdsecScheme,
 		Host:     bouncer.crowdsecHost,
-		Path:     crowdsecLapiRoute,
+		Path:     bouncer.crowdsecPath + crowdsecLapiRoute,
 		RawQuery: fmt.Sprintf("ip=%v&banned=true", remoteIP),
 	}
 	body, err := crowdsecQuery(bouncer, routeURL.String(), false)
@@ -506,7 +510,7 @@ func handleStreamCache(bouncer *Bouncer) error {
 	streamRouteURL := url.URL{
 		Scheme:   bouncer.crowdsecScheme,
 		Host:     bouncer.crowdsecHost,
-		Path:     bouncer.crowdsecStreamRoute,
+		Path:     bouncer.crowdsecPath + bouncer.crowdsecStreamRoute,
 		RawQuery: fmt.Sprintf("startup=%t", !isCrowdsecStreamHealthy || isStartup),
 	}
 	body, err := crowdsecQuery(bouncer, streamRouteURL.String(), false)

--- a/bouncer.go
+++ b/bouncer.go
@@ -62,6 +62,7 @@ type Bouncer struct {
 	enabled                 bool
 	appsecEnabled           bool
 	appsecHost              string
+	appsecPath              string
 	appsecFailureBlock      bool
 	appsecUnreachableBlock  bool
 	crowdsecScheme          string
@@ -147,6 +148,7 @@ func New(_ context.Context, next http.Handler, config *configuration.Config, nam
 		crowdsecMode:            config.CrowdsecMode,
 		appsecEnabled:           config.CrowdsecAppsecEnabled,
 		appsecHost:              config.CrowdsecAppsecHost,
+		appsecPath:              config.CrowdsecAppsecPath,
 		appsecFailureBlock:      config.CrowdsecAppsecFailureBlock,
 		appsecUnreachableBlock:  config.CrowdsecAppsecUnreachableBlock,
 		crowdsecScheme:          config.CrowdsecLapiScheme,
@@ -584,7 +586,7 @@ func appsecQuery(bouncer *Bouncer, ip string, httpReq *http.Request) error {
 	routeURL := url.URL{
 		Scheme: bouncer.crowdsecScheme,
 		Host:   bouncer.appsecHost,
-		Path:   "/",
+		Path:   bouncer.appsecPath,
 	}
 	var req *http.Request
 	if httpReq.Body != nil && httpReq.ContentLength > 0 {

--- a/examples/standalone-mode/README.md
+++ b/examples/standalone-mode/README.md
@@ -3,7 +3,9 @@ You need to create a crowdsec API credentials for the CAPI.
 You can follow the documentation here: https://docs.crowdsec.net/docs/central_api/intro
 
 ```bash
-curl -X POST "https://api.crowdsec.net/v2/watchers" -H  "accept: application/json" -H  "Content-Type: application/json" -d "{ \"password\": \"PASSWORD\",  \"machine_id\": \"LOGIN\"}"
+LOGIN=...
+PASSWORD=...
+curl -X POST "https://api.crowdsec.net/v2/watchers" -H "accept: application/json" -H "Content-Type: application/json" -d "{ \"password\": \"$PASSWORD\",  \"machine_id\": \"$LOGIN\"}"
 ```
 
 These CAPI credentials must be set in your docker-compose.yml or in your config files

--- a/examples/standalone-mode/docker-compose.yml
+++ b/examples/standalone-mode/docker-compose.yml
@@ -35,8 +35,7 @@ services:
 
       - "traefik.http.middlewares.crowdsec.plugin.bouncer.enabled=true"
       # - "traefik.http.middlewares.crowdsec.plugin.bouncer.loglevel=DEBUG"
-      - "traefik.http.middlewares.crowdsec.plugin.bouncer.crowdsecmode=alone"
-      - "traefik.http.middlewares.crowdsec.plugin.bouncer.crowdseclapikey=40796d93c2958f9e58345514e67740e5"
+      - "traefik.http.middlewares.crowdsec.plugin.bouncer.crowdsecMode=alone"
       - "traefik.http.middlewares.crowdsec.plugin.bouncer.CrowdsecCapiMachineId=FIXME"
       - "traefik.http.middlewares.crowdsec.plugin.bouncer.CrowdsecCapiPassword=FIXME"
       - "traefik.http.middlewares.crowdsec.plugin.bouncer.crowdseccapiscenarios=crowdsecurity/sshd,crowdsecurity/asterisk_bf,crowdsecurity/asterisk_user_enum,crowdsecurity/base-http-scenarios"

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -45,6 +45,7 @@ type Config struct {
 	CrowdsecAppsecUnreachableBlock           bool     `json:"crowdsecAppsecUnreachableBlock,omitempty"`
 	CrowdsecLapiScheme                       string   `json:"crowdsecLapiScheme,omitempty"`
 	CrowdsecLapiHost                         string   `json:"crowdsecLapiHost,omitempty"`
+	CrowdsecLapiPath                         string   `json:"crowdsecLapiPath,omitempty"`
 	CrowdsecLapiKey                          string   `json:"crowdsecLapiKey,omitempty"`
 	CrowdsecLapiKeyFile                      string   `json:"crowdsecLapiKeyFile,omitempty"`
 	CrowdsecLapiTLSInsecureVerify            bool     `json:"crowdsecLapiTlsInsecureVerify,omitempty"`
@@ -104,6 +105,7 @@ func New() *Config {
 		CrowdsecAppsecUnreachableBlock: true,
 		CrowdsecLapiScheme:             HTTP,
 		CrowdsecLapiHost:               "crowdsec:8080",
+		CrowdsecLapiPath:               "/",
 		CrowdsecLapiKey:                "",
 		CrowdsecLapiTLSInsecureVerify:  false,
 		UpdateIntervalSeconds:          60,
@@ -219,7 +221,7 @@ func ValidateParams(config *Config) error {
 		}
 	}
 
-	if err := validateURL("CrowdsecLapi", config.CrowdsecLapiScheme, config.CrowdsecLapiHost, "/"); err != nil {
+	if err := validateURL("CrowdsecLapi", config.CrowdsecLapiScheme, config.CrowdsecLapiHost, config.CrowdsecLapiPath); err != nil {
 		return err
 	}
 
@@ -259,11 +261,11 @@ func ValidateParams(config *Config) error {
 	return nil
 }
 
-func validateURL(variable, scheme, host string, path string) error {
+func validateURL(variable, scheme, host, path string, path string) error {
 	// This only check that the format of the URL scheme://host/path is correct and do not make requests
 	testURL := url.URL{Scheme: scheme, Host: host, Path: path}
 	if _, err := http.NewRequest(http.MethodGet, testURL.String(), nil); err != nil {
-		return fmt.Errorf("CrowdsecLapiScheme://%sHost: '%v://%v' must be an URL", variable, scheme, host)
+		return fmt.Errorf("CrowdsecLapiScheme://%sHost: '%v://%v%v' must be a valid URL", variable, scheme, host, path)
 	}
 	return nil
 }

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -40,6 +40,7 @@ type Config struct {
 	CrowdsecMode                             string   `json:"crowdsecMode,omitempty"`
 	CrowdsecAppsecEnabled                    bool     `json:"crowdsecAppsecEnabled,omitempty"`
 	CrowdsecAppsecHost                       string   `json:"crowdsecAppsecHost,omitempty"`
+	CrowdsecAppsecPath                       string   `json:"crowdsecAppsecPath,omitempty"`
 	CrowdsecAppsecFailureBlock               bool     `json:"crowdsecAppsecFailureBlock,omitempty"`
 	CrowdsecAppsecUnreachableBlock           bool     `json:"crowdsecAppsecUnreachableBlock,omitempty"`
 	CrowdsecLapiScheme                       string   `json:"crowdsecLapiScheme,omitempty"`
@@ -98,6 +99,7 @@ func New() *Config {
 		CrowdsecMode:                   LiveMode,
 		CrowdsecAppsecEnabled:          false,
 		CrowdsecAppsecHost:             "crowdsec:7422",
+		CrowdsecAppsecPath:             "/",
 		CrowdsecAppsecFailureBlock:     true,
 		CrowdsecAppsecUnreachableBlock: true,
 		CrowdsecLapiScheme:             HTTP,
@@ -217,11 +219,11 @@ func ValidateParams(config *Config) error {
 		}
 	}
 
-	if err := validateURL("CrowdsecLapi", config.CrowdsecLapiScheme, config.CrowdsecLapiHost); err != nil {
+	if err := validateURL("CrowdsecLapi", config.CrowdsecLapiScheme, config.CrowdsecLapiHost, "/"); err != nil {
 		return err
 	}
 
-	if err := validateURL("CrowdsecAppsec", config.CrowdsecLapiScheme, config.CrowdsecAppsecHost); err != nil {
+	if err := validateURL("CrowdsecAppsec", config.CrowdsecLapiScheme, config.CrowdsecAppsecHost, config.CrowdsecAppsecPath); err != nil {
 		return err
 	}
 
@@ -257,9 +259,9 @@ func ValidateParams(config *Config) error {
 	return nil
 }
 
-func validateURL(variable, scheme, host string) error {
-	// This only check that the format of the URL scheme://host is correct and do not make requests
-	testURL := url.URL{Scheme: scheme, Host: host}
+func validateURL(variable, scheme, host string, path string) error {
+	// This only check that the format of the URL scheme://host/path is correct and do not make requests
+	testURL := url.URL{Scheme: scheme, Host: host, Path: path}
 	if _, err := http.NewRequest(http.MethodGet, testURL.String(), nil); err != nil {
 		return fmt.Errorf("CrowdsecLapiScheme://%sHost: '%v://%v' must be an URL", variable, scheme, host)
 	}


### PR DESCRIPTION
This PR adds the ability to configure a Path for the AppSec. This is useful when you deploy CrowdSec via Helm and want multiple WAF-Acquisition with different configurations on the same Port.

E.g.:

```yaml
acquisitions:
  - source: appsec
    listen_addr: "0.0.0.0:7422"
    path: /waf1
    appsec_config: config1
    labels:
      type: appsec
  - source: appsec
    listen_addr: "0.0.0.0:7422"
    path: /waf2
    appsec_config: config2
    labels:
      type: appsec
```