### PR TITLE
always set custom remediation header if configured for bans

### DIFF
--- a/bouncer.go
+++ b/bouncer.go
@@ -335,14 +335,14 @@ type Login struct {
 
 // To append Headers we need to call rw.WriteHeader after set any header.
 func handleBanServeHTTP(bouncer *Bouncer, rw http.ResponseWriter) {
+	if bouncer.remediationCustomHeader != "" {
+		rw.Header().Set(bouncer.remediationCustomHeader, "ban")
+	}
 	if bouncer.banTemplateString == "" {
 		rw.WriteHeader(http.StatusForbidden)
 		return
 	}
 	rw.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if bouncer.remediationCustomHeader != "" {
-		rw.Header().Set(bouncer.remediationCustomHeader, "ban")
-	}
 	rw.WriteHeader(http.StatusForbidden)
 	fmt.Fprint(rw, bouncer.banTemplateString)
 }


### PR DESCRIPTION
This fixes a minor issue reported by a user: the config option `remediationHeadersCustomName` is ignored if `banHTMLFilePath` is empty (or if the template used is empty for some reason).