### PR TITLE
Minor fixes to captcha

### DIFF
--- a/bouncer.go
+++ b/bouncer.go
@@ -366,7 +366,6 @@ func handleRemediationServeHTTP(bouncer *Bouncer, remoteIP, remediation string, 
 				handleNextServeHTTP(bouncer, remoteIP, rw, req)
 				return
 			}
-			bouncer.captchaRequestCount.Add(1)
 			bouncer.captchaClient.ServeHTTP(rw, req, remoteIP)
 			return
 		} else {

--- a/captcha.html
+++ b/captcha.html
@@ -276,6 +276,13 @@
         line-height: 2.5rem
       }
     }
+
+    div.g-recaptcha {
+      margin: 0 auto;
+      width: 304px;
+      margin-top: 20px;
+      margin-bottom: 20px;
+    }
   </style>
   <script src="{{ .FrontendJS }}" async defer></script>
 </head>


### PR DESCRIPTION
A couple of nitpicks I found while setting up captcha support:

*  Add error to logs when remediation is set to captcha, but captcha client is not valid.
* Fix styles for default captcha html so that the actual captcha is centered in screen

This is what it looked before the fix:

![image](https://github.com/user-attachments/assets/0643503b-5055-46aa-b432-6b90f98edab2)

I found it weird that the docs have actual images of hcaptcha setup instead of google recaptcha, yet they state hcaptcha is not supported.

