### PR TITLE
configure appsecAppScheme independently of appsecLapiScheme

### DIFF
--- a/bouncer.go
+++ b/bouncer.go
@@ -61,6 +61,7 @@ type Bouncer struct {
 
 	enabled                 bool
 	appsecEnabled           bool
+	appsecScheme            string
 	appsecHost              string
 	appsecPath              string
 	appsecFailureBlock      bool
@@ -153,6 +154,7 @@ func New(_ context.Context, next http.Handler, config *configuration.Config, nam
 		enabled:                 config.Enabled,
 		crowdsecMode:            config.CrowdsecMode,
 		appsecEnabled:           config.CrowdsecAppsecEnabled,
+		appsecScheme:            config.CrowdsecAppsecScheme,
 		appsecHost:              config.CrowdsecAppsecHost,
 		appsecPath:              config.CrowdsecAppsecPath,
 		appsecFailureBlock:      config.CrowdsecAppsecFailureBlock,
@@ -601,7 +603,7 @@ func crowdsecQuery(bouncer *Bouncer, stringURL string, isPost bool) ([]byte, err
 
 func appsecQuery(bouncer *Bouncer, ip string, httpReq *http.Request) error {
 	routeURL := url.URL{
-		Scheme: bouncer.crowdsecScheme,
+		Scheme: bouncer.appsecScheme,
 		Host:   bouncer.appsecHost,
 		Path:   bouncer.appsecPath,
 	}

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -43,6 +43,7 @@ type Config struct {
 	LogFilePath                              string   `json:"logFilePath,omitempty"`
 	CrowdsecMode                             string   `json:"crowdsecMode,omitempty"`
 	CrowdsecAppsecEnabled                    bool     `json:"crowdsecAppsecEnabled,omitempty"`
+	CrowdsecAppsecScheme                     string   `json:"crowdsecAppsecScheme,omitempty"`
 	CrowdsecAppsecHost                       string   `json:"crowdsecAppsecHost,omitempty"`
 	CrowdsecAppsecPath                       string   `json:"crowdsecAppsecPath,omitempty"`
 	CrowdsecAppsecFailureBlock               bool     `json:"crowdsecAppsecFailureBlock,omitempty"`


### PR DESCRIPTION
We have the crowdsecLapi running with https. The crowdsecAppsec seems not to be able to run un https as of yet. The current config reuses the crowdsecLapiScheme for the connection to the crowdsecAppsec. I separated the config so you can specify http for crowdsecAppsec.