### PR TITLE
Kubernetes example: Set traefik logs to json so it can actually be parsed

### DIFF
--- a/examples/kubernetes/traefik/values.yml
+++ b/examples/kubernetes/traefik/values.yml
@@ -6,6 +6,7 @@ logs:
     level: DEBUG
   access:
     enabled: true
+    format: json
     fields:
       headers: 
         defaultmode: keep


### PR DESCRIPTION
Tried the example, couldn't figure out why it wasn't working - turned out the default isn't json anymore