### PR TITLE
Fix query of the GET /decisions endpoint

### DIFF
--- a/bouncer.go
+++ b/bouncer.go
@@ -428,7 +428,7 @@ func handleNoStreamCache(bouncer *Bouncer, remoteIP string) (string, error) {
 		Scheme:   bouncer.crowdsecScheme,
 		Host:     bouncer.crowdsecHost,
 		Path:     bouncer.crowdsecPath + crowdsecLapiRoute,
-		RawQuery: fmt.Sprintf("ip=%v&banned=true", remoteIP),
+		RawQuery: fmt.Sprintf("ip=%v", remoteIP),
 	}
 	body, err := crowdsecQuery(bouncer, routeURL.String(), false)
 	if err != nil {


### PR DESCRIPTION
banned=true query parameter doesn't exist, use type=ban based on LAPI dcoumentation https://crowdsecurity.github.io/api_doc/lapi/#/Remediation%20component/getDecisions

testing the endpoint 
![image](https://github.com/user-attachments/assets/626bcb5e-aa5a-4131-b5ec-c70aaf3823f3)


