### PR TITLE
✅Add e2e tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,8 +104,8 @@ jobs:
       - name: Run Integration Tests
         shell: pwsh
         run: |
-          # Run the integration test script
-          ./Test-Integration.ps1 -HttpTimeoutSeconds 60
+          # Run the integration test script (skip cleanup for log collection on failure)
+          ./Test-Integration.ps1 -HttpTimeoutSeconds 60 -SkipDockerCleanup
 
       - name: Show logs on failure
         if: failure()
@@ -116,6 +116,8 @@ jobs:
           docker logs crowdsec-test 2>/dev/null || echo "No CrowdSec container logs"
           echo "=== Traefik logs ==="
           docker logs traefik-test 2>/dev/null || echo "No Traefik container logs"
+          echo "=== Traefik Access Logs ==="
+          docker exec traefik-test cat /var/log/traefik/access.log 2>/dev/null || echo "No Traefik access logs"
           echo "=== Whoami logs ==="
           docker logs whoami-test 2>/dev/null || echo "No Whoami container logs"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,12 +110,14 @@ jobs:
       - name: Show logs on failure
         if: failure()
         run: |
+          echo "=== Docker container status ==="
+          docker ps -a
           echo "=== CrowdSec logs ==="
-          docker compose -f docker-compose.test.yml logs crowdsec 2>/dev/null || echo "No CrowdSec logs"
+          docker logs crowdsec-test 2>/dev/null || echo "No CrowdSec container logs"
           echo "=== Traefik logs ==="
-          docker compose -f docker-compose.test.yml logs traefik 2>/dev/null || echo "No Traefik logs"
+          docker logs traefik-test 2>/dev/null || echo "No Traefik container logs"
           echo "=== Whoami logs ==="
-          docker compose -f docker-compose.test.yml logs whoami 2>/dev/null || echo "No Whoami logs"
+          docker logs whoami-test 2>/dev/null || echo "No Whoami container logs"
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,3 +70,61 @@ jobs:
         run: make yaegi_test
         env:
           GOPATH: ${{ github.workspace }}/go
+
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Install PowerShell and Pester
+        run: |
+          # Set non-interactive mode to avoid prompts
+          export DEBIAN_FRONTEND=noninteractive
+          
+          sudo apt-get update
+          sudo apt-get install -y wget apt-transport-https software-properties-common
+          
+          # Download and install Microsoft signing key and repository
+          wget -q "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb"
+          
+          # Use dpkg with force-confdef and force-confold to handle config conflicts automatically
+          sudo dpkg --force-confdef --force-confold -i packages-microsoft-prod.deb
+          
+          sudo apt-get update
+          sudo apt-get install -y powershell
+          
+          # Install Pester testing framework
+          pwsh -c "Install-Module -Name Pester -Force -Scope CurrentUser -SkipPublisherCheck"
+
+      - name: Run Integration Tests
+        shell: pwsh
+        run: |
+          # Run the integration test script
+          ./Test-Integration.ps1 -TestMode all -HttpTimeoutSeconds 60
+
+      - name: Show logs on failure
+        if: failure()
+        run: |
+          echo "=== CrowdSec logs ==="
+          docker compose -f docker-compose.test.yml logs crowdsec 2>/dev/null || echo "No CrowdSec logs"
+          echo "=== Traefik logs ==="
+          docker compose -f docker-compose.test.yml logs traefik 2>/dev/null || echo "No Traefik logs"
+          echo "=== Whoami logs ==="
+          docker compose -f docker-compose.test.yml logs whoami 2>/dev/null || echo "No Whoami logs"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: test-results.xml
+          if-no-files-found: ignore
+
+      - name: Cleanup
+        if: always()
+        run: docker compose -f docker-compose.test.yml down -v --remove-orphans

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,9 @@ jobs:
           echo "=== Traefik logs ==="
           docker logs traefik-test 2>/dev/null || echo "No Traefik container logs"
           echo "=== Traefik Access Logs ==="
-          docker exec traefik-test cat /var/log/traefik/access.log 2>/dev/null || echo "No Traefik access logs"
+          docker exec traefik-test cat /var/log/traefik/access.log 2>/dev/null || echo "No current Traefik access logs"
+          echo "=== Traefik Access Logs Backup (from test runs) ==="
+          docker exec traefik-test cat /var/log/traefik/access.log.bak 2>/dev/null || echo "No Traefik access logs backup"
           echo "=== Whoami logs ==="
           docker logs whoami-test 2>/dev/null || echo "No Whoami container logs"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,7 @@ jobs:
         shell: pwsh
         run: |
           # Run the integration test script
-          ./Test-Integration.ps1 -TestMode all -HttpTimeoutSeconds 60
+          ./Test-Integration.ps1 -HttpTimeoutSeconds 60
 
       - name: Show logs on failure
         if: failure()

--- a/README.md
+++ b/README.md
@@ -681,6 +681,20 @@ docker exec crowdsec cscli decisions add --ip 10.0.0.10 -d 10m -t captcha # this
 docker exec crowdsec cscli decisions remove --ip 10.0.0.10 -t captcha
 ```
 
+### Testing
+
+#### Go Unit Tests
+
+```bash
+go test ./...
+```
+
+#### Integration Tests
+
+```bash
+./Test-Integration.ps1
+```
+
 ### Examples
 
 #### 1. Behind another proxy service (ex: clouflare) [examples/behind-proxy/README.md](https://github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/blob/main/examples/behind-proxy/README.md)

--- a/Test-Integration.ps1
+++ b/Test-Integration.ps1
@@ -1,0 +1,335 @@
+#!/usr/bin/env pwsh
+
+<#
+.SYNOPSIS
+    Runs integration tests for the CrowdSec Bouncer Traefik Plugin
+
+.DESCRIPTION
+    This script starts the Docker Compose services, waits for them to be ready,
+    runs the Pester integration tests covering different bouncer modes and scenarios,
+    and then cleans up the services.
+
+.PARAMETER SkipDockerCleanup
+    Skip stopping Docker services after tests complete (useful for debugging)
+
+.PARAMETER SkipWait
+    Skip waiting for services to be ready (assumes they're already running)
+
+.PARAMETER TestPath
+    Path to the Pester test files or directory (defaults to ./tests/ to run all test files)
+
+
+.PARAMETER HttpTimeoutSeconds
+    HTTP timeout for bouncer testing (defaults to 30)
+
+.EXAMPLE
+    ./Test-Integration.ps1
+    Runs the full integration test suite
+
+.EXAMPLE
+    ./Test-Integration.ps1 -TestPath "./tests/mode_stream.Tests.ps1" -HttpTimeoutSeconds 60
+    Tests only stream mode with 60 second timeout
+
+.EXAMPLE
+    ./Test-Integration.ps1 -SkipDockerCleanup
+    Runs tests but leaves Docker services running for debugging
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$SkipDockerCleanup,
+    [switch]$SkipWait,
+    [string]$TestPath = "./tests/",
+    [int]$HttpTimeoutSeconds = 30
+)
+
+$ErrorActionPreference = "Stop"
+
+# Colors for output
+$Colors = @{
+    Info = "Cyan"
+    Success = "Green"
+    Warning = "Yellow"
+    Error = "Red"
+}
+
+function Write-Step {
+    param([string]$Message, [string]$Color = "Cyan")
+    Write-Host "🔄 $Message" -ForegroundColor $Color
+}
+
+function Write-Success {
+    param([string]$Message)
+    Write-Host "✅ $Message" -ForegroundColor $Colors.Success
+}
+
+function Write-Warning {
+    param([string]$Message)
+    Write-Host "⚠️  $Message" -ForegroundColor $Colors.Warning
+}
+
+function Write-Error {
+    param([string]$Message)
+    Write-Host "❌ $Message" -ForegroundColor $Colors.Error
+}
+
+function Test-ServiceHealth {
+    param(
+        [string]$Url,
+        [string]$ServiceName,
+        [int]$TimeoutSeconds = 120,
+        [int]$RetryIntervalSeconds = 3,
+        [int]$ExpectedStatusCode = 200
+    )
+    
+    Write-Step "Waiting for $ServiceName to be ready..."
+    $elapsed = 0
+    
+    do {
+        try {
+            $response = Invoke-WebRequest -Uri $Url -Method Get -TimeoutSec 10 -UseBasicParsing -ErrorAction SilentlyContinue
+            if ($response.StatusCode -eq $ExpectedStatusCode) {
+                Write-Success "$ServiceName is ready! (Status: $($response.StatusCode))"
+                return $true
+            }
+        }
+        catch {
+            # Service not ready yet, continue waiting
+        }
+        
+        Start-Sleep $RetryIntervalSeconds
+        $elapsed += $RetryIntervalSeconds
+        
+        if ($elapsed % 15 -eq 0) {
+            Write-Host "  Still waiting for $ServiceName... ($elapsed/$TimeoutSeconds seconds)" -ForegroundColor Gray
+        }
+        
+    } while ($elapsed -lt $TimeoutSeconds)
+    
+    Write-Error "$ServiceName failed to become ready within $TimeoutSeconds seconds"
+    return $false
+}
+
+function Test-CrowdSecAPI {
+    param(
+        [string]$ApiKey,
+        [int]$TimeoutSeconds = 60
+    )
+    
+    Write-Step "Testing CrowdSec LAPI connection..."
+    $elapsed = 0
+    
+    do {
+        try {
+            $headers = @{ "X-Api-Key" = $ApiKey }
+            $response = Invoke-RestMethod -Uri "http://localhost:8081/v1/decisions?limit=1" -Headers $headers -TimeoutSec 5
+            Write-Success "CrowdSec LAPI is responding!"
+            return $true
+        }
+        catch {
+            Write-Host "  LAPI test failed: $($_.Exception.Message)" -ForegroundColor Yellow
+            Write-Host "  Status Code: $($_.Exception.Response.StatusCode)" -ForegroundColor Yellow
+            Start-Sleep 3
+            $elapsed += 3
+        }
+        
+    } while ($elapsed -lt $TimeoutSeconds)
+    
+    Write-Error "CrowdSec LAPI failed to respond within $TimeoutSeconds seconds"
+    return $false
+}
+
+# Main execution
+try {
+    Write-Host ""
+    Write-Host "🚀 CrowdSec Bouncer Traefik Plugin Integration Test Runner" -ForegroundColor $Colors.Info
+    Write-Host "=========================================================" -ForegroundColor $Colors.Info
+    Write-Host "Test Path: $TestPath" -ForegroundColor $Colors.Info
+    Write-Host "HTTP Timeout: $HttpTimeoutSeconds seconds" -ForegroundColor $Colors.Info
+    Write-Host ""
+
+    # Check if Pester is available
+    Write-Step "Checking Pester availability..."
+    try {
+        Import-Module Pester -Force -ErrorAction Stop
+        $pesterVersion = (Get-Module Pester).Version
+        if ($pesterVersion.Major -lt 5) {
+            Write-Warning "Pester version $pesterVersion detected. Upgrading to v5+..."
+            Install-Module -Name Pester -Force -Scope CurrentUser -SkipPublisherCheck
+            Import-Module Pester -Force
+        }
+        Write-Success "Pester $pesterVersion is available"
+    }
+    catch {
+        Write-Error "Pester module not found. Installing Pester..."
+        try {
+            Install-Module -Name Pester -Force -Scope CurrentUser -SkipPublisherCheck
+            Import-Module Pester -Force
+            Write-Success "Pester installed and imported successfully"
+        }
+        catch {
+            Write-Error "Failed to install Pester: $($_.Exception.Message)"
+            exit 1
+        }
+    }
+
+    # Ensure we are using Linux containers
+    Write-Step "Ensuring Linux containers are enabled..."
+    try {
+        $dockerInfo = docker info --format "{{.OSType}}" 2>$null
+        if ($dockerInfo -eq "linux") {
+            Write-Success "Docker is using Linux containers"
+        } else {
+            Write-Warning "Docker may not be using Linux containers. Some tests may fail."
+        }
+    }
+    catch {
+        Write-Warning "Could not verify Docker container type"
+    }
+
+    # Check if Docker Compose is available
+    Write-Step "Checking Docker Compose availability..."
+    try {
+        $dockerComposeVersion = docker compose version 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Success "Docker Compose is available"
+        } else {
+            throw "Docker Compose not found"
+        }
+    }
+    catch {
+        Write-Error "Docker Compose is not available. Please install Docker Desktop or Docker Compose."
+        exit 1
+    }
+
+    # Set environment variables for testing
+    $env:HTTP_TIMEOUT_SECONDS = $HttpTimeoutSeconds
+    $env:BOUNCER_API_KEY = "40796d93c2958f9e58345514e67740e5"
+
+    # Clean up any existing services
+    Write-Step "Cleaning up any existing services..."
+    docker compose -f docker-compose.test.yml down -v --remove-orphans 2>$null
+
+    # Start Docker services
+    Write-Step "Starting Docker Compose services for testing..."
+    try {
+        docker compose -f docker-compose.test.yml up -d
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to start Docker services"
+        }
+        Write-Success "Docker services started successfully"
+    }
+    catch {
+        Write-Error "Failed to start Docker services: $($_.Exception.Message)"
+        exit 1
+    }
+
+    if (-not $SkipWait) {
+        # Wait for services to be ready
+        Write-Step "Waiting for services to become ready..."
+        
+        $servicesReady = @(
+            (Test-ServiceHealth -Url "http://localhost:8080/api/rawdata" -ServiceName "Traefik API" -TimeoutSeconds 60),
+            (Test-ServiceHealth -Url "http://localhost:8000/whoami" -ServiceName "Whoami test service" -TimeoutSeconds 60),
+            (Test-CrowdSecAPI -ApiKey $env:BOUNCER_API_KEY -TimeoutSeconds 90)
+        )
+        
+        if ($servicesReady -contains $false) {
+            Write-Error "One or more services failed to start properly"
+            if (-not $SkipDockerCleanup) {
+                Write-Step "Cleaning up Docker services..."
+                docker compose -f docker-compose.test.yml down -v
+            }
+            exit 1
+        }
+        
+        Write-Success "All services are ready!"
+        
+        # Give CrowdSec a moment to fully initialize
+        Write-Step "Allowing CrowdSec to complete initialization..."
+        Start-Sleep 10
+        
+    } else {
+        Write-Warning "Skipping service readiness check (assuming services are already running)"
+    }
+
+    # Run Pester tests
+    Write-Step "Running Pester integration tests..."
+    Write-Host ""
+    
+    if (-not (Test-Path $TestPath)) {
+        Write-Error "Test path not found: $TestPath"
+        exit 1
+    }
+
+    try {
+        $pesterConfig = New-PesterConfiguration
+        $pesterConfig.Run.Path = $TestPath
+        $pesterConfig.Output.Verbosity = 'Detailed'
+        $pesterConfig.Run.Exit = $false
+        $pesterConfig.Run.PassThru = $true
+        $pesterConfig.TestResult.Enabled = $true
+        $pesterConfig.TestResult.OutputPath = "./test-results.xml"
+        
+        
+        $result = Invoke-Pester -Configuration $pesterConfig
+        
+        Write-Host ""
+        if ($result -and $result.FailedCount -eq 0) {
+            Write-Success "All integration tests passed! 🎉"
+            Write-Host "  Total: $($result.TotalCount)" -ForegroundColor Gray
+            Write-Host "  Passed: $($result.PassedCount)" -ForegroundColor $Colors.Success
+            Write-Host "  Duration: $($result.Duration)" -ForegroundColor Gray
+            $exitCode = 0
+        } elseif ($result) {
+            Write-Error "$($result.FailedCount) test(s) failed out of $($result.TotalCount) total tests"
+            Write-Host "  Passed: $($result.PassedCount)" -ForegroundColor $Colors.Success
+            Write-Host "  Failed: $($result.FailedCount)" -ForegroundColor $Colors.Error
+            Write-Host "  Skipped: $($result.SkippedCount)" -ForegroundColor $Colors.Warning
+            Write-Host "  Duration: $($result.Duration)" -ForegroundColor Gray
+            $exitCode = 1
+        } else {
+            Write-Warning "Could not determine test results"
+            $exitCode = 1
+        }
+    }
+    catch {
+        Write-Error "Failed to run Pester tests: $($_.Exception.Message)"
+        $exitCode = 1
+    }
+}
+catch {
+    Write-Error "Unexpected error: $($_.Exception.Message)"
+    $exitCode = 1
+}
+finally {
+    # Cleanup Docker services
+    if (-not $SkipDockerCleanup) {
+        Write-Step "Cleaning up Docker services..."
+        try {
+            docker compose -f docker-compose.test.yml down -v --remove-orphans 2>$null
+            Write-Success "Docker services stopped and cleaned up"
+        }
+        catch {
+            Write-Warning "Failed to clean up Docker services: $($_.Exception.Message)"
+        }
+    } else {
+        Write-Warning "Skipping Docker cleanup (services left running for debugging)"
+        Write-Host "To manually stop services, run: docker compose -f docker-compose.test.yml down -v" -ForegroundColor Gray
+        Write-Host "Services available at:" -ForegroundColor Gray
+        Write-Host "  - Traefik Dashboard: http://localhost:8080" -ForegroundColor Gray
+        Write-Host "  - Test Service: http://localhost:8000/whoami" -ForegroundColor Gray
+        Write-Host "  - CrowdSec LAPI: http://localhost:8081/v1/decisions" -ForegroundColor Gray
+    }
+    
+    Write-Host ""
+    Write-Host "=========================================================" -ForegroundColor $Colors.Info
+    if ($exitCode -eq 0) {
+        Write-Host "🏁 Integration tests completed successfully!" -ForegroundColor $Colors.Success
+    } else {
+        Write-Host "🏁 Integration tests completed with failures!" -ForegroundColor $Colors.Error
+    }
+    Write-Host ""
+}
+
+exit $exitCode 

--- a/Test-Integration.ps1
+++ b/Test-Integration.ps1
@@ -10,7 +10,7 @@
     and then cleans up the services.
 
 .PARAMETER SkipDockerCleanup
-    Skip stopping Docker services after tests complete (useful for debugging)
+    Skip stopping Docker services after tests complete (useful for debugging and CI log collection)
 
 .PARAMETER SkipWait
     Skip waiting for services to be ready (assumes they're already running)

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,6 +10,7 @@ services:
       - "--accesslog.format=json"
       - "--accesslog.bufferingSize=0"  # Disable buffering for immediate log writes in tests
       - "--accesslog.fields.headers.names.X-Crowdsec-Remediation=keep"
+      - "--accesslog.fields.headers.names.X-Forwarded-For=keep"
       - "--api.insecure=true"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,222 @@
+services:
+  traefik:
+    image: "traefik:v3.0.0"
+    container_name: "traefik-test"
+    restart: unless-stopped
+    command:
+      - "--log.level=DEBUG"
+      - "--accesslog"
+      - "--accesslog.filepath=/var/log/traefik/access.log"
+      - "--accesslog.format=json"
+      - "--accesslog.bufferingSize=0"  # Disable buffering for immediate log writes in tests
+      - "--accesslog.fields.headers.names.X-Crowdsec-Remediation=keep"
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.forwardedHeaders.trustedIPs=0.0.0.0/0"
+      - "--experimental.localplugins.bouncer.modulename=github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "traefik-logs:/var/log/traefik"
+      - "./ban.html:/ban.html:ro"
+      - "./captcha.html:/captcha.html:ro"
+      - "./:/plugins-local/src/github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin"
+    ports:
+      - "8000:80"
+      - "8080:8080"
+    depends_on:
+      - crowdsec
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/api/rawdata"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  # Test service - basic whoami
+  whoami:
+    image: traefik/whoami
+    container_name: "whoami-test"
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.whoami.rule=PathPrefix(`/whoami`)"
+      - "traefik.http.routers.whoami.entrypoints=web"
+      - "traefik.http.routers.whoami.middlewares=bouncer-test@docker"
+      - "traefik.http.services.whoami.loadbalancer.server.port=80"
+      
+      # Bouncer middleware with test configuration
+      - "traefik.http.middlewares.bouncer-test.plugin.bouncer.enabled=true"
+      - "traefik.http.middlewares.bouncer-test.plugin.bouncer.crowdseclapikey=40796d93c2958f9e58345514e67740e5"
+      - "traefik.http.middlewares.bouncer-test.plugin.bouncer.crowdseclapiurl=http://crowdsec:8080/"
+      - "traefik.http.middlewares.bouncer-test.plugin.bouncer.httptimeoutseconds=${HTTP_TIMEOUT_SECONDS:-30}"
+      - "traefik.http.middlewares.bouncer-test.plugin.bouncer.loglevel=DEBUG"
+      - "traefik.http.middlewares.bouncer-test.plugin.bouncer.updateintervalseconds=5"
+      - "traefik.http.middlewares.bouncer-test.plugin.bouncer.crowdsecmode=none"
+      - "traefik.http.middlewares.bouncer-test.plugin.bouncer.remediationHeadersCustomName=X-Crowdsec-Remediation"
+      - "traefik.http.middlewares.bouncer-test.plugin.bouncer.forwardedheaderstrustedips=0.0.0.0/0"
+      - "traefik.http.middlewares.bouncer-test.plugin.bouncer.forwardedheaderscustomname=X-Forwarded-For"
+
+  # Test service - protected endpoint
+  protected:
+    image: traefik/whoami
+    container_name: "protected-test"
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.protected.rule=PathPrefix(`/protected`)"
+      - "traefik.http.routers.protected.entrypoints=web"
+      - "traefik.http.routers.protected.middlewares=bouncer-strict@docker"
+      - "traefik.http.services.protected.loadbalancer.server.port=80"
+      
+      # Strict bouncer middleware for testing blocks
+      - "traefik.http.middlewares.bouncer-strict.plugin.bouncer.enabled=true"
+      - "traefik.http.middlewares.bouncer-strict.plugin.bouncer.crowdseclapikey=40796d93c2958f9e58345514e67740e5"
+      - "traefik.http.middlewares.bouncer-strict.plugin.bouncer.crowdseclapiurl=http://crowdsec:8080/"
+      - "traefik.http.middlewares.bouncer-strict.plugin.bouncer.httptimeoutseconds=${HTTP_TIMEOUT_SECONDS:-30}"
+      - "traefik.http.middlewares.bouncer-strict.plugin.bouncer.loglevel=DEBUG"
+      - "traefik.http.middlewares.bouncer-strict.plugin.bouncer.updateintervalseconds=5"
+      - "traefik.http.middlewares.bouncer-strict.plugin.bouncer.crowdsecmode=none"
+      - "traefik.http.middlewares.bouncer-strict.plugin.bouncer.banHtmlFilePath=/ban.html"
+      - "traefik.http.middlewares.bouncer-strict.plugin.bouncer.forwardedheaderstrustedips=0.0.0.0/0"
+      - "traefik.http.middlewares.bouncer-strict.plugin.bouncer.forwardedheaderscustomname=X-Forwarded-For"
+
+  # Test service - captcha enabled
+  captcha:
+    image: traefik/whoami
+    container_name: "captcha-test"
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.captcha.rule=PathPrefix(`/captcha`)"
+      - "traefik.http.routers.captcha.entrypoints=web"
+      - "traefik.http.routers.captcha.middlewares=bouncer-captcha@docker"
+      - "traefik.http.services.captcha.loadbalancer.server.port=80"
+      
+      # Captcha-enabled bouncer middleware
+      - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.enabled=true"
+      - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.crowdseclapikey=40796d93c2958f9e58345514e67740e5"
+      - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.crowdseclapiurl=http://crowdsec:8080/"
+      - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.httptimeoutseconds=${HTTP_TIMEOUT_SECONDS:-30}"
+      - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.loglevel=DEBUG"
+      - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.updateintervalseconds=5"
+      - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.crowdsecmode=none"
+      - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.captchaHtmlFilePath=/captcha.html"
+      - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.captchaProvider=hcaptcha"
+      - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.captchaSiteKey=test-site-key"
+      - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.captchaSecretKey=test-secret-key"
+      - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.remediationHeadersCustomName=X-Crowdsec-Remediation"
+      - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.forwardedheaderstrustedips=0.0.0.0/0"
+      - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.forwardedheaderscustomname=X-Forwarded-For"
+
+  # Test service - disabled bouncer
+  disabled:
+    image: traefik/whoami
+    container_name: "disabled-test"
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.disabled.rule=PathPrefix(`/disabled`)"
+      - "traefik.http.routers.disabled.entrypoints=web"
+      - "traefik.http.routers.disabled.middlewares=bouncer-disabled@docker"
+      - "traefik.http.services.disabled.loadbalancer.server.port=80"
+      
+      # Disabled bouncer middleware
+      - "traefik.http.middlewares.bouncer-disabled.plugin.bouncer.enabled=false"
+      - "traefik.http.middlewares.bouncer-disabled.plugin.bouncer.crowdseclapikey=40796d93c2958f9e58345514e67740e5"
+      - "traefik.http.middlewares.bouncer-disabled.plugin.bouncer.loglevel=DEBUG"
+
+  # Test service - remediation headers
+  remediation-headers:
+    image: traefik/whoami
+    container_name: "remediation-headers-test"
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.remediation-headers.rule=PathPrefix(`/remediation-headers`)"
+      - "traefik.http.routers.remediation-headers.entrypoints=web"
+      - "traefik.http.routers.remediation-headers.middlewares=bouncer-remediation-headers@docker"
+      - "traefik.http.services.remediation-headers.loadbalancer.server.port=80"
+      
+      # Bouncer middleware with custom remediation header
+      - "traefik.http.middlewares.bouncer-remediation-headers.plugin.bouncer.enabled=true"
+      - "traefik.http.middlewares.bouncer-remediation-headers.plugin.bouncer.crowdseclapikey=40796d93c2958f9e58345514e67740e5"
+      - "traefik.http.middlewares.bouncer-remediation-headers.plugin.bouncer.crowdseclapiurl=http://crowdsec:8080/"
+      - "traefik.http.middlewares.bouncer-remediation-headers.plugin.bouncer.httptimeoutseconds=${HTTP_TIMEOUT_SECONDS:-30}"
+      - "traefik.http.middlewares.bouncer-remediation-headers.plugin.bouncer.loglevel=DEBUG"
+      - "traefik.http.middlewares.bouncer-remediation-headers.plugin.bouncer.updateintervalseconds=5"
+      - "traefik.http.middlewares.bouncer-remediation-headers.plugin.bouncer.crowdsecmode=none"
+      - "traefik.http.middlewares.bouncer-remediation-headers.plugin.bouncer.remediationHeadersCustomName=X-Crowdsec-Remediation"
+      - "traefik.http.middlewares.bouncer-remediation-headers.plugin.bouncer.banHtmlFilePath=/ban.html"
+      - "traefik.http.middlewares.bouncer-remediation-headers.plugin.bouncer.forwardedheaderstrustedips=0.0.0.0/0"
+      - "traefik.http.middlewares.bouncer-remediation-headers.plugin.bouncer.forwardedheaderscustomname=X-Forwarded-For"
+
+  # Test service - stream mode
+  stream:
+    image: traefik/whoami
+    container_name: "stream-test"
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.stream.rule=PathPrefix(`/stream`)"
+      - "traefik.http.routers.stream.entrypoints=web"
+      - "traefik.http.routers.stream.middlewares=bouncer-stream@docker"
+      - "traefik.http.services.stream.loadbalancer.server.port=80"
+      
+      # Stream mode bouncer middleware
+      - "traefik.http.middlewares.bouncer-stream.plugin.bouncer.enabled=true"
+      - "traefik.http.middlewares.bouncer-stream.plugin.bouncer.crowdseclapikey=40796d93c2958f9e58345514e67740e5"
+      - "traefik.http.middlewares.bouncer-stream.plugin.bouncer.crowdseclapiurl=http://crowdsec:8080/"
+      - "traefik.http.middlewares.bouncer-stream.plugin.bouncer.httptimeoutseconds=${HTTP_TIMEOUT_SECONDS:-30}"
+      - "traefik.http.middlewares.bouncer-stream.plugin.bouncer.loglevel=DEBUG"
+      - "traefik.http.middlewares.bouncer-stream.plugin.bouncer.updateintervalseconds=5"
+      - "traefik.http.middlewares.bouncer-stream.plugin.bouncer.crowdsecmode=stream"
+      - "traefik.http.middlewares.bouncer-stream.plugin.bouncer.forwardedheaderstrustedips=0.0.0.0/0"
+      - "traefik.http.middlewares.bouncer-stream.plugin.bouncer.forwardedheaderscustomname=X-Forwarded-For"
+
+  crowdsec:
+    image: crowdsecurity/crowdsec:v1.6.8
+    container_name: "crowdsec-test"
+    restart: unless-stopped
+    environment:
+      # Minimal collections for testing
+      COLLECTIONS: "crowdsecurity/traefik"
+      CUSTOM_HOSTNAME: "crowdsec-test"
+      # Test bouncer key
+      BOUNCER_KEY_TRAEFIK_TEST: "40796d93c2958f9e58345514e67740e5"
+      # Disable aggressive collections that cause 150k decision issue
+      DISABLE_COLLECTIONS: "crowdsecurity/iptables crowdsecurity/linux crowdsecurity/sshd"
+      # Enable debugging
+      PARSERS: "crowdsecurity/syslog-logs crowdsecurity/dateparse-enrich"
+      # Minimal setup for testing
+      DISABLE_AGENT: "false"
+      DISABLE_ONLINE_API: "true"
+      # Test mode settings
+      LEVEL_DEBUG: "true"
+      # Use persistent volumes to cache downloaded databases
+    volumes:
+      - "crowdsec-db-test:/var/lib/crowdsec/data/"
+      - "crowdsec-config-test:/etc/crowdsec/"
+    labels:
+      - "traefik.enable=false"
+    healthcheck:
+      test: ["CMD", "cscli", "version"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    ports:
+      # Expose LAPI for testing
+      - "8081:8080"
+
+
+
+volumes:
+  crowdsec-db-test:
+  crowdsec-config-test:
+  traefik-logs:
+
+networks:
+  default:
+    name: crowdsec-test-network 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -15,7 +15,7 @@ services:
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
       - "--entrypoints.web.address=:80"
-      - "--entrypoints.web.forwardedHeaders.trustedIPs=0.0.0.0/0"
+      - "--entrypoints.web.forwardedHeaders.trustedIPs=172.20.0.0/16"
       - "--experimental.localplugins.bouncer.modulename=github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
@@ -56,7 +56,7 @@ services:
       - "traefik.http.middlewares.bouncer-test.plugin.bouncer.updateintervalseconds=5"
       - "traefik.http.middlewares.bouncer-test.plugin.bouncer.crowdsecmode=none"
       - "traefik.http.middlewares.bouncer-test.plugin.bouncer.remediationHeadersCustomName=X-Crowdsec-Remediation"
-      - "traefik.http.middlewares.bouncer-test.plugin.bouncer.forwardedheaderstrustedips=0.0.0.0/0"
+      - "traefik.http.middlewares.bouncer-test.plugin.bouncer.forwardedheaderstrustedips=172.20.0.1/32"
       - "traefik.http.middlewares.bouncer-test.plugin.bouncer.forwardedheaderscustomname=X-Forwarded-For"
 
   # Test service - protected endpoint
@@ -80,7 +80,7 @@ services:
       - "traefik.http.middlewares.bouncer-strict.plugin.bouncer.updateintervalseconds=5"
       - "traefik.http.middlewares.bouncer-strict.plugin.bouncer.crowdsecmode=none"
       - "traefik.http.middlewares.bouncer-strict.plugin.bouncer.banHtmlFilePath=/ban.html"
-      - "traefik.http.middlewares.bouncer-strict.plugin.bouncer.forwardedheaderstrustedips=0.0.0.0/0"
+      - "traefik.http.middlewares.bouncer-strict.plugin.bouncer.forwardedheaderstrustedips=172.20.0.1/32"
       - "traefik.http.middlewares.bouncer-strict.plugin.bouncer.forwardedheaderscustomname=X-Forwarded-For"
 
   # Test service - captcha enabled
@@ -108,7 +108,7 @@ services:
       - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.captchaSiteKey=test-site-key"
       - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.captchaSecretKey=test-secret-key"
       - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.remediationHeadersCustomName=X-Crowdsec-Remediation"
-      - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.forwardedheaderstrustedips=0.0.0.0/0"
+      - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.forwardedheaderstrustedips=172.20.0.1/32"
       - "traefik.http.middlewares.bouncer-captcha.plugin.bouncer.forwardedheaderscustomname=X-Forwarded-For"
 
   # Test service - disabled bouncer
@@ -150,7 +150,7 @@ services:
       - "traefik.http.middlewares.bouncer-remediation-headers.plugin.bouncer.crowdsecmode=none"
       - "traefik.http.middlewares.bouncer-remediation-headers.plugin.bouncer.remediationHeadersCustomName=X-Crowdsec-Remediation"
       - "traefik.http.middlewares.bouncer-remediation-headers.plugin.bouncer.banHtmlFilePath=/ban.html"
-      - "traefik.http.middlewares.bouncer-remediation-headers.plugin.bouncer.forwardedheaderstrustedips=0.0.0.0/0"
+      - "traefik.http.middlewares.bouncer-remediation-headers.plugin.bouncer.forwardedheaderstrustedips=172.20.0.1/32"
       - "traefik.http.middlewares.bouncer-remediation-headers.plugin.bouncer.forwardedheaderscustomname=X-Forwarded-For"
 
   # Test service - stream mode
@@ -173,7 +173,7 @@ services:
       - "traefik.http.middlewares.bouncer-stream.plugin.bouncer.loglevel=DEBUG"
       - "traefik.http.middlewares.bouncer-stream.plugin.bouncer.updateintervalseconds=5"
       - "traefik.http.middlewares.bouncer-stream.plugin.bouncer.crowdsecmode=stream"
-      - "traefik.http.middlewares.bouncer-stream.plugin.bouncer.forwardedheaderstrustedips=0.0.0.0/0"
+      - "traefik.http.middlewares.bouncer-stream.plugin.bouncer.forwardedheaderstrustedips=172.20.0.1/32"
       - "traefik.http.middlewares.bouncer-stream.plugin.bouncer.forwardedheaderscustomname=X-Forwarded-For"
 
   crowdsec:
@@ -220,4 +220,8 @@ volumes:
 
 networks:
   default:
-    name: crowdsec-test-network 
+    name: crowdsec-test-network
+    ipam:
+      config:
+        - subnet: 172.20.0.0/16
+          gateway: 172.20.0.1 

--- a/tests/TestUtils.ps1
+++ b/tests/TestUtils.ps1
@@ -271,7 +271,7 @@ function Get-TraefikAccessLogs {
     }
 }
 
-# Helper function to clear Traefik access logs
+# Helper function to clear Traefik access logs (with backup for CI debugging)
 function Clear-TraefikAccessLogs {
     param(
         [string]$ContainerName = "traefik-test",
@@ -279,6 +279,11 @@ function Clear-TraefikAccessLogs {
     )
     
     Write-Host "🧹 Clearing Traefik access logs..." -ForegroundColor Yellow
+    
+    # Append current log contents to backup for CI debugging before clearing
+    docker exec $ContainerName sh -c "cat $LogPath >> ${LogPath}.bak 2>/dev/null || touch ${LogPath}.bak" 2>$null
+    
+    # Clear the main log file
     docker exec $ContainerName sh -c "echo '' > $LogPath" 2>$null
 }
 

--- a/tests/TestUtils.ps1
+++ b/tests/TestUtils.ps1
@@ -1,0 +1,324 @@
+#!/usr/bin/env pwsh
+
+# Shared utility functions for CrowdSec Bouncer integration tests
+# This file contains reusable helper functions for all test suites
+
+# Helper function to call CrowdSec LAPI
+function Invoke-CrowdSecAPI {
+    param(
+        [string]$Endpoint,
+        [string]$Method = "GET",
+        [object]$Body = $null,
+        [int]$TimeoutSec = 10,
+        [string]$ApiKey = "40796d93c2958f9e58345514e67740e5",
+        [string]$CrowdSecApiUrl = "http://localhost:8081"
+    )
+    
+    $headers = @{
+        "X-Api-Key" = $ApiKey
+        "Content-Type" = "application/json"
+    }
+    
+    $uri = "$CrowdSecApiUrl$Endpoint"
+    
+    try {
+        if ($Body) {
+            $jsonBody = $Body | ConvertTo-Json -Depth 10
+            return Invoke-RestMethod -Uri $uri -Method $Method -Headers $headers -Body $jsonBody -TimeoutSec $TimeoutSec
+        } else {
+            return Invoke-RestMethod -Uri $uri -Method $Method -Headers $headers -TimeoutSec $TimeoutSec
+        }
+    }
+    catch {
+        Write-Host "❌ LAPI call failed: $($_.Exception.Message)" -ForegroundColor Red
+        throw
+    }
+}
+
+# Helper function to create a decision using cscli
+function Add-TestDecision {
+    param(
+        [string]$IP,
+        [string]$Type = "ban",
+        [string]$Duration = "1h",
+        [string]$Scenario = "integration-test",
+        [string]$Reason = "Integration test decision"
+    )
+    
+    Write-Host "➕ Adding $Type decision for $IP" -ForegroundColor Yellow
+    
+    $addCommand = "cscli decisions add --ip $IP --duration $Duration --type $Type --reason '$Reason'"
+    $result = docker exec crowdsec-test sh -c $addCommand
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to add decision: $result"
+    }
+    
+    Write-Host "✅ Decision added successfully via cscli" -ForegroundColor Green
+    return $true
+}
+
+# Helper function to remove decisions for an IP using cscli
+function Remove-TestDecision {
+    param(
+        [string]$IP
+    )
+    
+    $result = docker exec crowdsec-test cscli decisions delete --ip $IP 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "⚠️ Failed to remove decisions for $IP" -ForegroundColor Yellow
+    } else {
+        Write-Host "✅ Removed decisions for $IP" -ForegroundColor Green
+    }
+    return $true
+}
+
+# Helper function to test HTTP request
+function Test-HttpRequest {
+    param(
+        [string]$Endpoint,
+        [string]$IP,
+        [int]$ExpectedStatusCode = 200,
+        [string]$ExpectedContent = $null,
+        [int]$TimeoutSec = 10,
+        [string]$TraefikUrl = "http://localhost:8000"
+    )
+    
+    $headers = @{
+        "X-Forwarded-For" = $IP
+        "User-Agent" = "Integration-Test-Client"
+    }
+    
+    try {
+        $response = Invoke-WebRequest -Uri "$TraefikUrl$Endpoint" -Headers $headers -TimeoutSec $TimeoutSec -UseBasicParsing
+        
+        return @{
+            StatusCode = $response.StatusCode
+            Content = $response.Content
+            Success = $true
+        }
+    }
+    catch {
+        $statusCode = 0
+        $content = ""
+        
+        if ($_.Exception.Response) {
+            $statusCode = [int]$_.Exception.Response.StatusCode
+            $content = $_.Exception.Response.Content ?? ""
+        }
+        
+        return @{
+            StatusCode = $statusCode
+            Content = $content
+            Success = $false
+            Error = $_.Exception.Message
+        }
+    }
+}
+
+# Helper function to wait for a specific HTTP status code with timeout
+function Wait-ForHttpStatus {
+    param(
+        [string]$Url,
+        [hashtable]$Headers = @{},
+        [int[]]$ExpectedStatusCodes = @(200),
+        [int]$TimeoutSeconds = 15,
+        [int]$RetryIntervalSeconds = 1
+    )
+    
+    $elapsed = 0
+    $lastStatusCode = 0
+    $lastError = ""
+    
+    do {
+        try {
+            $response = Invoke-WebRequest -Uri $Url -Headers $Headers -UseBasicParsing -TimeoutSec 5
+            $lastStatusCode = $response.StatusCode
+            if ($ExpectedStatusCodes -contains $lastStatusCode) {
+                return @{
+                    Success = $true
+                    StatusCode = $lastStatusCode
+                    TimeTaken = $elapsed
+                }
+            }
+        }
+        catch {
+            if ($_.Exception.Response) {
+                $lastStatusCode = [int]$_.Exception.Response.StatusCode
+                if ($ExpectedStatusCodes -contains $lastStatusCode) {
+                    return @{
+                        Success = $true
+                        StatusCode = $lastStatusCode
+                        TimeTaken = $elapsed
+                    }
+                }
+            }
+            $lastError = $_.Exception.Message
+        }
+        
+        Start-Sleep $RetryIntervalSeconds
+        $elapsed += $RetryIntervalSeconds
+        
+    } while ($elapsed -lt $TimeoutSeconds)
+    
+    return @{
+        Success = $false
+        StatusCode = $lastStatusCode
+        TimeTaken = $elapsed
+        Error = $lastError
+    }
+}
+
+# Helper function to wait for a condition to be met with retry logic
+function Wait-ForCondition {
+    param(
+        [scriptblock]$Condition,
+        [string]$Description = "Condition",
+        [int]$TimeoutSeconds = 30,
+        [int]$RetryIntervalSeconds = 1,
+        [switch]$Silent
+    )
+    
+    $elapsed = 0
+    $lastError = ""
+    
+    if (-not $Silent) {
+        Write-Host "🔄 Waiting for $Description..." -ForegroundColor Cyan
+    }
+    
+    do {
+        try {
+            $result = & $Condition
+            if ($result) {
+                if (-not $Silent) {
+                    Write-Host "✅ $Description met after $elapsed seconds" -ForegroundColor Green
+                }
+                return @{
+                    Success = $true
+                    TimeTaken = $elapsed
+                }
+            }
+        }
+        catch {
+            $lastError = $_.Exception.Message
+        }
+        
+        Start-Sleep $RetryIntervalSeconds
+        $elapsed += $RetryIntervalSeconds
+        
+        if ($elapsed % 10 -eq 0 -and -not $Silent) {
+            Write-Host "  Still waiting for $Description... ($elapsed/$TimeoutSeconds seconds)" -ForegroundColor Gray
+        }
+        
+    } while ($elapsed -lt $TimeoutSeconds)
+    
+    if (-not $Silent) {
+        Write-Host "❌ $Description not met within $TimeoutSeconds seconds" -ForegroundColor Red
+        if ($lastError) {
+            Write-Host "  Last error: $lastError" -ForegroundColor Yellow
+        }
+    }
+    
+    return @{
+        Success = $false
+        TimeTaken = $elapsed
+        Error = $lastError
+    }
+}
+
+# Helper function to read and parse Traefik access logs
+function Get-TraefikAccessLogs {
+    param(
+        [string]$ContainerName = "traefik-test",
+        [string]$LogPath = "/var/log/traefik/access.log"
+    )
+    
+    # Read the access logs
+    Write-Host "📋 Reading Traefik access logs..." -ForegroundColor Yellow
+    $logContent = docker exec $ContainerName cat $LogPath
+    
+    if ([string]::IsNullOrWhiteSpace($logContent)) {
+        Write-Host "⚠️ No access log content found" -ForegroundColor Yellow
+        return @{
+            Success = $false
+            RawContent = ""
+            LogEntries = @()
+            Error = "No access log content found"
+        }
+    }
+    
+    Write-Host "📄 Access log content:" -ForegroundColor Gray
+    Write-Host $logContent -ForegroundColor Gray
+    
+    # Parse the JSON log entries
+    $logLines = $logContent -split "`n" | Where-Object { $_.Trim() -ne "" }
+    $parsedEntries = @()
+    
+    foreach ($line in $logLines) {
+        try {
+            $logEntry = $line | ConvertFrom-Json
+            $parsedEntries += $logEntry
+        }
+        catch {
+            Write-Host "⚠️ Could not parse log line: $line" -ForegroundColor Yellow
+        }
+    }
+    
+    return @{
+        Success = $true
+        RawContent = $logContent
+        LogEntries = $parsedEntries
+        Count = $parsedEntries.Count
+    }
+}
+
+# Helper function to clear Traefik access logs
+function Clear-TraefikAccessLogs {
+    param(
+        [string]$ContainerName = "traefik-test",
+        [string]$LogPath = "/var/log/traefik/access.log"
+    )
+    
+    Write-Host "🧹 Clearing Traefik access logs..." -ForegroundColor Yellow
+    docker exec $ContainerName sh -c "echo '' > $LogPath" 2>$null
+}
+
+# Helper function to find specific log entries using a condition callback
+function Find-TraefikLogEntry {
+    param(
+        [object[]]$LogEntries,
+        [scriptblock]$Condition,
+        [string]$Description = "matching log entry"
+    )
+    
+    foreach ($logEntry in $LogEntries) {
+        try {
+            # Execute the condition callback with the log entry
+            $matches = & $Condition $logEntry
+            if ($matches) {
+                Write-Host "✅ Found $Description" -ForegroundColor Green
+                return @{
+                    Found = $true
+                    LogEntry = $logEntry
+                }
+            }
+        }
+        catch {
+            # Skip invalid log entries or condition errors
+            Write-Host "⚠️ Error evaluating condition for log entry" -ForegroundColor Yellow
+        }
+    }
+    
+    Write-Host "❌ No $Description found in access logs" -ForegroundColor Red
+    Write-Host "Available log entries:" -ForegroundColor Yellow
+    foreach ($logEntry in $LogEntries) {
+        try {
+            Write-Host "  Path: $($logEntry.RequestPath), Status: $($logEntry.DownstreamStatus)" -ForegroundColor Yellow
+        }
+        catch { }
+    }
+    
+    return @{
+        Found = $false
+        LogEntry = $null
+    }
+}

--- a/tests/TestUtils.ps1
+++ b/tests/TestUtils.ps1
@@ -327,3 +327,14 @@ function Find-TraefikLogEntry {
         LogEntry = $null
     }
 }
+
+# Helper function to remove all decisions using cscli
+function Remove-AllTestDecisions {
+    docker exec crowdsec-test cscli decisions delete --all 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "⚠️ Failed to remove all decisions" -ForegroundColor Yellow
+    } else {
+        Write-Host "✅ Removed all decisions" -ForegroundColor Green
+    }
+    return $true
+}

--- a/tests/captcha.Tests.ps1
+++ b/tests/captcha.Tests.ps1
@@ -1,0 +1,134 @@
+#!/usr/bin/env pwsh
+
+# Captcha Remediation Tests for CrowdSec Bouncer Traefik Plugin
+# Tests bouncer behavior when applying captcha remediation
+
+BeforeAll {
+    # Import shared test utilities
+    . "$PSScriptRoot/TestUtils.ps1"
+    
+    # Test configuration
+    $script:TraefikUrl = "http://localhost:8000"
+    $script:CrowdSecApiUrl = "http://localhost:8081"
+    $script:ApiKey = "40796d93c2958f9e58345514e67740e5"
+    $script:HttpTimeoutSeconds = [int]($env:HTTP_TIMEOUT_SECONDS ?? 30)
+    
+    # Test IP addresses - using Docker network IPs that the bouncer actually sees
+    $script:TestIPs = @{
+        BannedIP  = "172.19.0.1"
+        CaptchaIP = "172.19.0.2" 
+        CleanIP   = "172.19.0.3"
+    }
+    
+    # Wait for CrowdSec LAPI to be ready
+    $result = Wait-ForCondition -Description "CrowdSec LAPI to be ready" -TimeoutSeconds 60 -RetryIntervalSeconds 2 -Condition {
+        Invoke-CrowdSecAPI -Endpoint "/v1/decisions?limit=1" -TimeoutSec 5 -ApiKey $script:ApiKey -CrowdSecApiUrl $script:CrowdSecApiUrl
+        return $true
+    }
+    
+    if (-not $result.Success) {
+        throw "❌ CrowdSec LAPI failed to become ready"
+    }
+}
+
+Describe "CrowdSec Bouncer Captcha Remediation Tests" {
+    
+    Context "Captcha Remediation Tests" -Tag "captcha" {
+        
+        BeforeEach {
+            # Clear Traefik access logs for clean test isolation
+            Clear-TraefikAccessLogs
+            # Clean up any existing decisions
+            foreach ($ip in $script:TestIPs.Values) {
+                try { Remove-TestDecision -IP $ip } catch { }
+            }
+        }
+        
+        It "Should show captcha remediation for captcha decision" {
+            # Add captcha decision for the IP the bouncer actually sees
+            Add-TestDecision -IP $script:TestIPs.BannedIP -Type "captcha"
+            
+            # Test captcha endpoint
+            $response = Test-HttpRequest -Endpoint "/captcha" -IP $script:TestIPs.CaptchaIP -TraefikUrl $script:TraefikUrl
+            $response.StatusCode | Should -BeIn @(200, 429)
+            
+            # If captcha is working, response should contain captcha content
+            if ($response.StatusCode -eq 200) {
+                $response.Content | Should -Match "captcha|challenge"
+            }
+            
+            # Verify custom remediation header in Traefik access logs
+            $logResult = Get-TraefikAccessLogs
+            $logResult.Success | Should -Be $true -Because "Should be able to read Traefik access logs"
+            
+            # Find log entry for captcha endpoint with remediation header
+            $result = Find-TraefikLogEntry -LogEntries $logResult.LogEntries -Description "captcha log entry with remediation header" -Condition {
+                param($logEntry)
+                return ($logEntry.RequestPath -eq "/captcha" -and $logEntry.'downstream_X-Crowdsec-Remediation' -eq "captcha")
+            }
+            
+            $result.Found | Should -Be $true -Because "Custom remediation header should appear in Traefik access logs for captcha decisions"
+            
+            if ($result.Found) {
+                $remediationHeader = $result.LogEntry.'downstream_X-Crowdsec-Remediation'
+                Write-Host "  Header value: $remediationHeader" -ForegroundColor Green
+                Write-Host "  Status code: $($result.LogEntry.DownstreamStatus)" -ForegroundColor Green
+            }
+        }
+        
+        It "Should fallback to ban when captcha is not configured" {
+            # Add captcha decision for the IP the bouncer actually sees
+            Add-TestDecision -IP $script:TestIPs.BannedIP -Type "captcha"
+            
+            # Test an endpoint without captcha configuration (should fallback to ban)
+            $response = Test-HttpRequest -Endpoint "/whoami" -IP $script:TestIPs.CaptchaIP -TraefikUrl $script:TraefikUrl
+            $response.StatusCode | Should -BeIn @(403, 429) -Because "Should fallback to ban when captcha is not configured"
+            
+            # Verify custom remediation header shows 'ban' fallback
+            $logResult = Get-TraefikAccessLogs
+            $logResult.Success | Should -Be $true -Because "Should be able to read Traefik access logs"
+            
+            # Find log entry for whoami endpoint with ban remediation header (fallback)
+            $result = Find-TraefikLogEntry -LogEntries $logResult.LogEntries -Description "whoami log entry with ban fallback header" -Condition {
+                param($logEntry)
+                return ($logEntry.RequestPath -eq "/whoami" -and $logEntry.'downstream_X-Crowdsec-Remediation' -eq "ban")
+            }
+            
+            $result.Found | Should -Be $true -Because "Should fallback to ban remediation when captcha is not configured"
+            
+            if ($result.Found) {
+                $remediationHeader = $result.LogEntry.'downstream_X-Crowdsec-Remediation'
+                Write-Host "  Fallback header value: $remediationHeader" -ForegroundColor Green
+                Write-Host "  Status code: $($result.LogEntry.DownstreamStatus)" -ForegroundColor Green
+            }
+        }
+        
+        It "Should show ban remediation for ban decision even on captcha endpoint" {
+            # Add ban decision (not captcha) for the IP the bouncer actually sees
+            Add-TestDecision -IP $script:TestIPs.BannedIP -Type "ban"
+            
+            # Test captcha endpoint with ban decision (should show ban, not captcha)
+            $response = Test-HttpRequest -Endpoint "/captcha" -IP $script:TestIPs.CaptchaIP -TraefikUrl $script:TraefikUrl
+            $response.StatusCode | Should -BeIn @(403, 429) -Because "Ban decision should block request even on captcha endpoint"
+            
+            # Verify custom remediation header shows 'ban' (decision type overrides endpoint config)
+            $logResult = Get-TraefikAccessLogs
+            $logResult.Success | Should -Be $true -Because "Should be able to read Traefik access logs"
+            
+            # Find log entry for captcha endpoint with ban remediation header
+            $result = Find-TraefikLogEntry -LogEntries $logResult.LogEntries -Description "captcha endpoint log entry with ban header" -Condition {
+                param($logEntry)
+                return ($logEntry.RequestPath -eq "/captcha" -and $logEntry.'downstream_X-Crowdsec-Remediation' -eq "ban")
+            }
+            
+            $result.Found | Should -Be $true -Because "Ban decision should result in ban remediation even on captcha-configured endpoint"
+            
+            if ($result.Found) {
+                $remediationHeader = $result.LogEntry.'downstream_X-Crowdsec-Remediation'
+                Write-Host "  Ban header value: $remediationHeader" -ForegroundColor Green
+                Write-Host "  Status code: $($result.LogEntry.DownstreamStatus)" -ForegroundColor Green
+            }
+        }
+    }
+}
+

--- a/tests/mode_none.Tests.ps1
+++ b/tests/mode_none.Tests.ps1
@@ -36,12 +36,8 @@ Describe "CrowdSec Bouncer None Mode Tests" {
     Context "Basic Bouncer Functionality" -Tag "none" {
         
         BeforeEach {
-            # Clear Traefik access logs for clean test isolation
             Clear-TraefikAccessLogs
-            # Clean up any existing decisions
-            foreach ($ip in $script:TestIPs.Values) {
-                try { Remove-TestDecision -IP $ip } catch { }
-            }
+            Remove-AllTestDecisions
         }
         
         It "Should allow clean IP through" {
@@ -85,12 +81,8 @@ Describe "CrowdSec Bouncer None Mode Tests" {
     Context "Performance Tests" -Tag "none" {
         
         BeforeEach {
-            # Clear Traefik access logs for clean test isolation
             Clear-TraefikAccessLogs
-            # Clean up any existing decisions
-            foreach ($ip in $script:TestIPs.Values) {
-                try { Remove-TestDecision -IP $ip } catch { }
-            }
+            Remove-AllTestDecisions
         }
         
         It "Should handle requests within reasonable time" {

--- a/tests/mode_none.Tests.ps1
+++ b/tests/mode_none.Tests.ps1
@@ -1,0 +1,122 @@
+#!/usr/bin/env pwsh
+
+# None Mode Tests for CrowdSec Bouncer Traefik Plugin
+# Tests bouncer behavior in 'none' mode (immediate LAPI queries, no caching)
+
+BeforeAll {
+    # Import shared test utilities
+    . "$PSScriptRoot/TestUtils.ps1"
+    
+    # Test configuration
+    $script:TraefikUrl = "http://localhost:8000"
+    $script:CrowdSecApiUrl = "http://localhost:8081"
+    $script:ApiKey = "40796d93c2958f9e58345514e67740e5"
+    $script:HttpTimeoutSeconds = [int]($env:HTTP_TIMEOUT_SECONDS ?? 30)
+    
+    # Test IP addresses - using Docker network IPs that the bouncer actually sees
+    $script:TestIPs = @{
+        BannedIP = "172.19.0.1"
+        CaptchaIP = "172.19.0.2" 
+        CleanIP = "172.19.0.3"
+    }
+    
+    # Wait for CrowdSec LAPI to be ready
+    $result = Wait-ForCondition -Description "CrowdSec LAPI to be ready" -TimeoutSeconds 60 -RetryIntervalSeconds 2 -Condition {
+        Invoke-CrowdSecAPI -Endpoint "/v1/decisions?limit=1" -TimeoutSec 5 -ApiKey $script:ApiKey -CrowdSecApiUrl $script:CrowdSecApiUrl
+        return $true
+    }
+    
+    if (-not $result.Success) {
+        throw "❌ CrowdSec LAPI failed to become ready"
+    }
+}
+
+Describe "CrowdSec Bouncer None Mode Tests" {
+    
+    Context "Basic Bouncer Functionality" -Tag "none" {
+        
+        BeforeEach {
+            # Clear Traefik access logs for clean test isolation
+            Clear-TraefikAccessLogs
+            # Clean up any existing decisions
+            foreach ($ip in $script:TestIPs.Values) {
+                try { Remove-TestDecision -IP $ip } catch { }
+            }
+        }
+        
+        It "Should allow clean IP through" {
+            $response = Test-HttpRequest -Endpoint "/whoami" -IP $script:TestIPs.CleanIP -TraefikUrl $script:TraefikUrl
+            $response.Success | Should -Be $true
+            $response.StatusCode | Should -Be 200
+            $response.Content | Should -Match "Hostname"
+        }
+        
+        It "Should block banned IP immediately" {
+            # Add ban decision
+            Add-TestDecision -IP $script:TestIPs.BannedIP -Type "ban"
+            
+            # In 'none' mode, bouncer queries LAPI immediately - no wait needed
+            
+            # Test that IP is blocked
+            $response = Test-HttpRequest -Endpoint "/whoami" -IP $script:TestIPs.BannedIP -TraefikUrl $script:TraefikUrl
+            $response.StatusCode | Should -BeIn @(403, 429)
+        }
+        
+        It "Should unblock IP immediately after decision removal" {
+            # Add ban decision
+            Add-TestDecision -IP $script:TestIPs.BannedIP -Type "ban"
+            
+            # Verify it's blocked
+            $response = Test-HttpRequest -Endpoint "/whoami" -IP $script:TestIPs.BannedIP -TraefikUrl $script:TraefikUrl
+            $response.StatusCode | Should -BeIn @(403, 429)
+            
+            # Remove decision
+            Remove-TestDecision -IP $script:TestIPs.BannedIP
+            
+            # In 'none' mode, bouncer queries LAPI immediately - no wait needed
+            
+            # Verify it's now allowed
+            $response = Test-HttpRequest -Endpoint "/whoami" -IP $script:TestIPs.BannedIP -TraefikUrl $script:TraefikUrl
+            $response.Success | Should -Be $true
+            $response.StatusCode | Should -Be 200
+        }
+    }
+    
+    Context "Performance Tests" -Tag "none" {
+        
+        BeforeEach {
+            # Clear Traefik access logs for clean test isolation
+            Clear-TraefikAccessLogs
+            # Clean up any existing decisions
+            foreach ($ip in $script:TestIPs.Values) {
+                try { Remove-TestDecision -IP $ip } catch { }
+            }
+        }
+        
+        It "Should handle requests within reasonable time" {
+            $measureTime = Measure-Command {
+                $response = Test-HttpRequest -Endpoint "/whoami" -IP $script:TestIPs.CleanIP -TraefikUrl $script:TraefikUrl
+                $response.Success | Should -Be $true
+            }
+            
+            # Request should complete within 5 seconds
+            $measureTime.TotalSeconds | Should -BeLessThan 5
+        }
+        
+        It "Should handle blocked requests efficiently" {
+            # Add ban decision
+            Add-TestDecision -IP $script:TestIPs.BannedIP -Type "ban"
+            
+            # In 'none' mode, bouncer queries LAPI immediately - no wait needed
+            
+            $measureTime = Measure-Command {
+                $response = Test-HttpRequest -Endpoint "/whoami" -IP $script:TestIPs.BannedIP -TraefikUrl $script:TraefikUrl
+                $response.StatusCode | Should -BeIn @(403, 429)
+            }
+            
+            # Blocked request should be fast (no backend processing)
+            $measureTime.TotalSeconds | Should -BeLessThan 2
+        }
+    }
+}
+

--- a/tests/mode_stream.Tests.ps1
+++ b/tests/mode_stream.Tests.ps1
@@ -1,0 +1,91 @@
+#!/usr/bin/env pwsh
+
+# Stream Mode Tests for CrowdSec Bouncer Traefik Plugin
+# Tests bouncer behavior in 'stream' mode (local cache with periodic updates)
+
+BeforeAll {
+    # Import shared test utilities
+    . "$PSScriptRoot/TestUtils.ps1"
+    
+    # Test configuration
+    $script:TraefikUrl = "http://localhost:8000"
+    $script:CrowdSecApiUrl = "http://localhost:8081"
+    $script:ApiKey = "40796d93c2958f9e58345514e67740e5"
+    $script:HttpTimeoutSeconds = [int]($env:HTTP_TIMEOUT_SECONDS ?? 30)
+    
+    # Test IP addresses - using Docker network IPs that the bouncer actually sees
+    $script:TestIPs = @{
+        BannedIP = "172.19.0.1"
+        CaptchaIP = "172.19.0.2" 
+        CleanIP = "172.19.0.3"
+    }
+    
+    # Wait for CrowdSec LAPI to be ready
+    $result = Wait-ForCondition -Description "CrowdSec LAPI to be ready" -TimeoutSeconds 60 -RetryIntervalSeconds 2 -Condition {
+        Invoke-CrowdSecAPI -Endpoint "/v1/decisions?limit=1" -TimeoutSec 5 -ApiKey $script:ApiKey -CrowdSecApiUrl $script:CrowdSecApiUrl
+        return $true
+    }
+    
+    if (-not $result.Success) {
+        throw "❌ CrowdSec LAPI failed to become ready"
+    }
+}
+
+Describe "CrowdSec Bouncer Stream Mode Tests" {
+    
+    Context "Stream Mode Tests" -Tag "stream" {
+        
+        BeforeEach {
+            # Clear Traefik access logs for clean test isolation
+            Clear-TraefikAccessLogs
+            # Clean up any existing decisions
+            foreach ($ip in $script:TestIPs.Values) {
+                try { Remove-TestDecision -IP $ip } catch { }
+            }
+        }
+        
+        It "Should handle decisions with cache updates" {
+            # Add a decision for the client IP that will be seen by the stream mode bouncer
+            Add-TestDecision -IP $script:TestIPs.BannedIP -Type "ban"
+            
+            # Stream mode needs time to update its cache, so wait for the condition
+            $result = Wait-ForCondition -Description "Stream mode to block IP $($script:TestIPs.BannedIP)" -TimeoutSeconds 30 -RetryIntervalSeconds 2 -Condition {
+                $response = Test-HttpRequest -Endpoint "/stream" -IP $script:TestIPs.BannedIP -TraefikUrl $script:TraefikUrl
+                return ($response.StatusCode -in @(403, 429))
+            }
+            
+            $result.Success | Should -Be $true -Because "Stream mode should eventually block the banned IP"
+            
+            # Clean up
+            Remove-TestDecision -IP $script:TestIPs.BannedIP
+            
+            # Wait for stream mode to allow the IP again
+            $result = Wait-ForCondition -Description "Stream mode to allow IP $($script:TestIPs.BannedIP) after decision removal" -TimeoutSeconds 30 -RetryIntervalSeconds 2 -Condition {
+                $response = Test-HttpRequest -Endpoint "/stream" -IP $script:TestIPs.BannedIP -TraefikUrl $script:TraefikUrl
+                return ($response.StatusCode -eq 200)
+            }
+            
+            $result.Success | Should -Be $true -Because "Stream mode should eventually allow the IP after decision removal"
+        }
+        
+        It "Should handle decision updates within timeout" {
+            # This test ensures the bouncer can handle updates within the configured timeout
+            $measureTime = Measure-Command {
+                Add-TestDecision -IP $script:TestIPs.BannedIP -Type "ban"
+                
+                # Wait for stream mode to block the IP
+                $result = Wait-ForCondition -Description "Stream mode to block IP" -TimeoutSeconds 30 -RetryIntervalSeconds 1 -Silent -Condition {
+                    $response = Test-HttpRequest -Endpoint "/stream" -IP $script:TestIPs.BannedIP -TraefikUrl $script:TraefikUrl
+                    return ($response.StatusCode -in @(403, 429))
+                }
+                
+                $result.Success | Should -Be $true -Because "Stream mode should block the IP within timeout"
+                Remove-TestDecision -IP $script:TestIPs.BannedIP
+            }
+            
+            # The entire operation should complete within the configured timeout
+            $measureTime.TotalSeconds | Should -BeLessThan $script:HttpTimeoutSeconds
+        }
+    }
+}
+

--- a/tests/mode_stream.Tests.ps1
+++ b/tests/mode_stream.Tests.ps1
@@ -48,8 +48,8 @@ Describe "CrowdSec Bouncer Stream Mode Tests" {
             # Add a decision for the client IP that will be seen by the stream mode bouncer
             Add-TestDecision -IP $script:TestIPs.BannedIP -Type "ban"
             
-            # Stream mode initial sync can take very long, so use generous timeout
-            $result = Wait-ForCondition -Description "Stream mode to block IP $($script:TestIPs.BannedIP)" -TimeoutSeconds 120 -RetryIntervalSeconds 3 -Condition {
+            # Stream mode initial sync can take time, but keep timeout reasonable
+            $result = Wait-ForCondition -Description "Stream mode to block IP $($script:TestIPs.BannedIP)" -TimeoutSeconds 30 -RetryIntervalSeconds 2 -Condition {
                 $response = Test-HttpRequest -Endpoint "/stream" -IP $script:TestIPs.BannedIP -TraefikUrl $script:TraefikUrl
                 return ($response.StatusCode -in @(403, 429))
             }
@@ -60,7 +60,7 @@ Describe "CrowdSec Bouncer Stream Mode Tests" {
             Remove-TestDecision -IP $script:TestIPs.BannedIP
             
             # Wait for stream mode to allow the IP again (should be faster after initial sync)
-            $result = Wait-ForCondition -Description "Stream mode to allow IP $($script:TestIPs.BannedIP) after decision removal" -TimeoutSeconds 60 -RetryIntervalSeconds 3 -Condition {
+            $result = Wait-ForCondition -Description "Stream mode to allow IP $($script:TestIPs.BannedIP) after decision removal" -TimeoutSeconds 30 -RetryIntervalSeconds 2 -Condition {
                 $response = Test-HttpRequest -Endpoint "/stream" -IP $script:TestIPs.BannedIP -TraefikUrl $script:TraefikUrl
                 return ($response.StatusCode -eq 200)
             }
@@ -74,7 +74,7 @@ Describe "CrowdSec Bouncer Stream Mode Tests" {
                 Add-TestDecision -IP $script:TestIPs.BannedIP -Type "ban"
                 
                 # Wait for stream mode to block the IP (initial sync can be slow)
-                $result = Wait-ForCondition -Description "Stream mode to block IP" -TimeoutSeconds 90 -RetryIntervalSeconds 2 -Silent -Condition {
+                $result = Wait-ForCondition -Description "Stream mode to block IP" -TimeoutSeconds 30 -RetryIntervalSeconds 2 -Silent -Condition {
                     $response = Test-HttpRequest -Endpoint "/stream" -IP $script:TestIPs.BannedIP -TraefikUrl $script:TraefikUrl
                     return ($response.StatusCode -in @(403, 429))
                 }

--- a/tests/mode_stream.Tests.ps1
+++ b/tests/mode_stream.Tests.ps1
@@ -36,12 +36,8 @@ Describe "CrowdSec Bouncer Stream Mode Tests" {
     Context "Stream Mode Tests" -Tag "stream" {
         
         BeforeEach {
-            # Clear Traefik access logs for clean test isolation
             Clear-TraefikAccessLogs
-            # Clean up any existing decisions
-            foreach ($ip in $script:TestIPs.Values) {
-                try { Remove-TestDecision -IP $ip } catch { }
-            }
+            Remove-AllTestDecisions
         }
         
         It "Should handle decisions with cache updates" {

--- a/tests/simple-bouncer.Tests.ps1
+++ b/tests/simple-bouncer.Tests.ps1
@@ -45,8 +45,8 @@ BeforeAll {
 Describe "Basic CrowdSec Bouncer Integration Test" {
     
     BeforeEach {
-        # Clear Traefik access logs for clean test isolation
         Clear-TraefikAccessLogs
+        Remove-AllTestDecisions
     }
     
     It "Should allow access when no decision exists" {
@@ -121,8 +121,8 @@ Describe "Basic CrowdSec Bouncer Integration Test" {
 Describe "CrowdSec Bouncer General Tests" {
     
     BeforeEach {
-        # Clear Traefik access logs for clean test isolation
         Clear-TraefikAccessLogs
+        Remove-AllTestDecisions
     }
     
     Context "Service Health Checks" {

--- a/tests/simple-bouncer.Tests.ps1
+++ b/tests/simple-bouncer.Tests.ps1
@@ -1,0 +1,164 @@
+#!/usr/bin/env pwsh
+
+# Simple Integration Test for CrowdSec Bouncer
+# Focus: Prove basic functionality works
+
+BeforeAll {
+    # Import shared test utilities
+    . "$PSScriptRoot/TestUtils.ps1"
+    
+    $script:TraefikUrl = "http://localhost:8000"
+    $script:CrowdSecApiUrl = "http://localhost:8081"
+    $script:TestIP = "172.19.0.1"
+    
+    # Wait for Traefik to be ready
+    $result = Wait-ForCondition -Description "Traefik to be ready" -TimeoutSeconds 30 -RetryIntervalSeconds 2 -Condition {
+        try {
+            $response = Invoke-WebRequest -Uri "http://localhost:8000/disabled" -TimeoutSec 3 -UseBasicParsing
+            return ($response.StatusCode -eq 200)
+        }
+        catch {
+            return $false
+        }
+    }
+    
+    if (-not $result.Success) {
+        throw "❌ Traefik failed to become ready"
+    }
+    
+    # Set up bouncer API key for reading decisions (cscli handles writing)
+    Write-Host "🔍 Setting up CrowdSec API..." -ForegroundColor Yellow
+    $script:BouncerApiKey = "40796d93c2958f9e58345514e67740e5"
+    
+    # Test bouncer API
+    Write-Host "🔄 Testing CrowdSec bouncer API..." -ForegroundColor Cyan
+    try {
+        $response = Invoke-CrowdSecAPI -Endpoint "/v1/decisions?limit=1" -ApiKey $script:BouncerApiKey -CrowdSecApiUrl $script:CrowdSecApiUrl
+        Write-Host "✅ CrowdSec bouncer API is working!" -ForegroundColor Green
+    }
+    catch {
+        Write-Host "❌ Bouncer API test failed: $($_.Exception.Message)" -ForegroundColor Red
+        throw "CrowdSec bouncer API not accessible"
+    }
+}
+
+Describe "Basic CrowdSec Bouncer Integration Test" {
+    
+    BeforeEach {
+        # Clear Traefik access logs for clean test isolation
+        Clear-TraefikAccessLogs
+    }
+    
+    It "Should allow access when no decision exists" {
+        # Test that we can access the endpoint normally
+        $response = Test-HttpRequest -Endpoint "/whoami" -IP $script:TestIP -TraefikUrl $script:TraefikUrl
+        $response.StatusCode | Should -Be 200 -Because "Clean IP should be able to access endpoint"
+    }
+    
+    It "Should block access after adding a ban decision" {
+        # Add a ban decision using cscli (simpler than API)
+        Write-Host "➕ Adding ban decision for $script:TestIP" -ForegroundColor Yellow
+        
+        # Add a ban decision
+        Add-TestDecision -IP $script:TestIP -Type "ban" -Reason "Integration test"
+        
+        # With 0 cache time, the bouncer queries LAPI directly - no wait needed!
+        
+        # Now test that the IP is blocked
+        $response = Test-HttpRequest -Endpoint "/whoami" -IP $script:TestIP -TraefikUrl $script:TraefikUrl
+        $response.StatusCode | Should -BeIn @(403, 429) -Because "IP should be blocked after ban decision"
+    }
+    
+    It "Should allow access after removing the ban decision" {
+        # Remove the decision
+        Remove-TestDecision -IP $script:TestIP
+        
+        # With 0 cache time, the bouncer queries LAPI directly - no wait needed!
+        
+        # Now test that the IP can access again
+        $response = Test-HttpRequest -Endpoint "/whoami" -IP $script:TestIP -TraefikUrl $script:TraefikUrl
+        $response.StatusCode | Should -Be 200 -Because "IP should be able to access endpoint after decision removal"
+    }
+
+    It "Should include custom remediation header in Traefik access logs when blocking requests" {
+        # Clear logs first, then add a ban decision
+        Clear-TraefikAccessLogs
+        Add-TestDecision -IP $script:TestIP -Type "ban" -Reason "Custom header test"
+        
+        # Make a request to the endpoint with custom remediation headers configured
+        Write-Host "🌐 Making request to remediation-headers endpoint..." -ForegroundColor Yellow
+        $response = Test-HttpRequest -Endpoint "/remediation-headers" -IP $script:TestIP -TraefikUrl $script:TraefikUrl
+        
+        # We expect this to be blocked (403), but we're interested in the headers
+        $response.StatusCode | Should -BeIn @(403, 429) -Because "Banned IP should be blocked"
+        
+        # Get and parse Traefik access logs
+        $logResult = Get-TraefikAccessLogs
+        
+        if (-not $logResult.Success) {
+            throw $logResult.Error
+        }
+        
+        # Find log entry for remediation-headers endpoint with ban remediation header
+        $result = Find-TraefikLogEntry -LogEntries $logResult.LogEntries -Description "remediation-headers log entry with ban header" -Condition {
+            param($logEntry)
+            return ($logEntry.RequestPath -eq "/remediation-headers" -and $logEntry.'downstream_X-Crowdsec-Remediation' -eq "ban")
+        }
+        
+        $result.Found | Should -Be $true -Because "Custom remediation header should appear in Traefik access logs when blocking requests"
+        
+        if ($result.Found) {
+            $remediationHeader = $result.LogEntry.'downstream_X-Crowdsec-Remediation'
+            Write-Host "  Header value: $remediationHeader" -ForegroundColor Green
+            Write-Host "  Status code: $($result.LogEntry.DownstreamStatus)" -ForegroundColor Green
+        }
+        
+        # Cleanup: Remove the decision
+        Remove-TestDecision -IP $script:TestIP
+    }
+}
+
+Describe "CrowdSec Bouncer General Tests" {
+    
+    BeforeEach {
+        # Clear Traefik access logs for clean test isolation
+        Clear-TraefikAccessLogs
+    }
+    
+    Context "Service Health Checks" {
+        It "CrowdSec LAPI should be accessible" {
+            # Test that LAPI responds (null response is valid when no decisions exist)
+            { Invoke-CrowdSecAPI -Endpoint "/v1/decisions?limit=1" -ApiKey $script:BouncerApiKey -CrowdSecApiUrl $script:CrowdSecApiUrl } | Should -Not -Throw
+        }
+        
+        It "Traefik should be accessible" {
+            $response = Test-HttpRequest -Endpoint "/whoami" -IP "172.19.0.3" -TraefikUrl $script:TraefikUrl
+            $response.Success | Should -Be $true
+            $response.StatusCode | Should -Be 200
+        }
+    }
+    
+    Context "Disabled Bouncer Tests" -Tag "disabled" {
+        
+        It "Should allow all traffic when bouncer is disabled" {
+            # Test disabled endpoint should always allow traffic
+            $response = Test-HttpRequest -Endpoint "/disabled" -IP $script:TestIP -TraefikUrl $script:TraefikUrl
+            $response.Success | Should -Be $true
+            $response.StatusCode | Should -Be 200
+        }
+    }
+    
+    Context "Error Handling Tests" -Tag "error" {
+        
+        It "Should handle invalid decisions gracefully" {
+            # Try to add decision with invalid IP
+            { Add-TestDecision -IP "invalid.ip" -Type "ban" } | Should -Throw
+        }
+        
+        It "Should handle LAPI connectivity issues" {
+            # Test with wrong API key - should throw an exception
+            { Invoke-CrowdSecAPI -Endpoint "/v1/decisions?limit=1" -ApiKey "invalid-key" -CrowdSecApiUrl $script:CrowdSecApiUrl } | Should -Throw
+        }
+    }
+}
+


### PR DESCRIPTION
Add e2e tests with basic coverage. Using Pester+Powershell, it is cross platform.

Fixes #272

This PR **only** adds test coverage. It does not make any changes whatsoever to the bouncer itself.