### PR TITLE
🐛Not write response body for HEAD requests

### DIFF
--- a/bouncer.go
+++ b/bouncer.go
@@ -418,7 +418,7 @@ func handleBanServeHTTP(bouncer *Bouncer, rw http.ResponseWriter, method string)
 func handleRemediationServeHTTP(bouncer *Bouncer, remoteIP, remediation string, rw http.ResponseWriter, req *http.Request) {
 	bouncer.log.Debug(fmt.Sprintf("handleRemediationServeHTTP ip:%s remediation:%s", remoteIP, remediation))
 	// Only serve captcha for GET and POST requests, fallback to BAN for other methods. We need POST because the actual captcha post-processing is done in the POST request.
-	if bouncer.captchaClient.Valid && remediation == cache.CaptchaValue && (req.Method == http.MethodGet || req.Method == http.MethodPost) {
+	if bouncer.captchaClient.Valid && remediation == cache.CaptchaValue && (req.Method != http.MethodHead) {
 		if bouncer.captchaClient.Check(remoteIP) {
 			handleNextServeHTTP(bouncer, remoteIP, rw, req)
 			return

--- a/bouncer.go
+++ b/bouncer.go
@@ -417,7 +417,6 @@ func handleBanServeHTTP(bouncer *Bouncer, rw http.ResponseWriter, method string)
 
 func handleRemediationServeHTTP(bouncer *Bouncer, remoteIP, remediation string, rw http.ResponseWriter, req *http.Request) {
 	bouncer.log.Debug(fmt.Sprintf("handleRemediationServeHTTP ip:%s remediation:%s", remoteIP, remediation))
-	// Only serve captcha for GET and POST requests, fallback to BAN for other methods. We need POST because the actual captcha post-processing is done in the POST request.
 	if bouncer.captchaClient.Valid && remediation == cache.CaptchaValue && req.Method != http.MethodHead {
 		if bouncer.captchaClient.Check(remoteIP) {
 			handleNextServeHTTP(bouncer, remoteIP, rw, req)
@@ -427,7 +426,6 @@ func handleRemediationServeHTTP(bouncer *Bouncer, remoteIP, remediation string, 
 		bouncer.captchaClient.ServeHTTP(rw, req, remoteIP)
 		return
 	}
-	// For non-GET/POST requests or when captcha is not valid, serve ban response
 	handleBanServeHTTP(bouncer, rw, req.Method)
 }
 

--- a/bouncer.go
+++ b/bouncer.go
@@ -444,8 +444,7 @@ func handleNextServeHTTP(bouncer *Bouncer, remoteIP string, rw http.ResponseWrit
 
 func handleStreamTicker(bouncer *Bouncer) {
 	if err := handleStreamCache(bouncer); err != nil {
-		// use warn when https://github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/pull/276 is completed
-		bouncer.log.Info(fmt.Sprintf("handleStreamTicker updateFailure:%d isCrowdsecStreamHealthy:%t %s", updateFailure, isCrowdsecStreamHealthy, err.Error()))
+		bouncer.log.Debug(fmt.Sprintf("handleStreamTicker updateFailure:%d isCrowdsecStreamHealthy:%t %s", updateFailure, isCrowdsecStreamHealthy, err.Error()))
 		if bouncer.updateMaxFailure != -1 && updateFailure >= bouncer.updateMaxFailure && isCrowdsecStreamHealthy {
 			isCrowdsecStreamHealthy = false
 			bouncer.log.Error(fmt.Sprintf("handleStreamTicker:error updateFailure:%d %s", updateFailure, err.Error()))

--- a/bouncer_test.go
+++ b/bouncer_test.go
@@ -264,7 +264,6 @@ func TestHandleBanServeHTTPWithDifferentMethods(t *testing.T) {
 		})
 	}
 }
-
 func TestCaptchaMethodBasedLogic(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -291,23 +290,35 @@ func TestCaptchaMethodBasedLogic(t *testing.T) {
 			expectBanFallback: false,
 		},
 		{
-			name:              "PUT with captcha remediation should fallback to ban",
+			name:              "PUT with captcha remediation should allow captcha",
 			method:            http.MethodPut,
 			remediation:       cache.CaptchaValue,
-			expectBanFallback: true,
+			expectBanFallback: false,
 		},
 		{
-			name:              "DELETE with captcha remediation should fallback to ban",
+			name:              "DELETE with captcha remediation should allow captcha",
 			method:            http.MethodDelete,
 			remediation:       cache.CaptchaValue,
-			expectBanFallback: true,
+			expectBanFallback: false,
+		},
+		{
+			name:              "PATCH with captcha remediation should allow captcha",
+			method:            http.MethodPatch,
+			remediation:       cache.CaptchaValue,
+			expectBanFallback: false,
+		},
+		{
+			name:              "OPTIONS with captcha remediation should allow captcha",
+			method:            http.MethodOptions,
+			remediation:       cache.CaptchaValue,
+			expectBanFallback: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Test the core logic: should we use captcha or fallback to ban?
-			shouldUseCaptcha := tt.remediation == cache.CaptchaValue && (tt.method == http.MethodGet || tt.method == http.MethodPost)
+			// Test the core logic: captcha is served for all methods except HEAD
+			shouldUseCaptcha := tt.remediation == cache.CaptchaValue && tt.method != http.MethodHead
 
 			if shouldUseCaptcha == tt.expectBanFallback {
 				t.Errorf("Method %s with %s remediation: expected ban fallback %v, but logic would use captcha %v",

--- a/bouncer_test.go
+++ b/bouncer_test.go
@@ -186,3 +186,133 @@ func Test_crowdsecQuery(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleBanServeHTTPWithDifferentMethods(t *testing.T) {
+	tests := []struct {
+		name              string
+		method            string
+		banTemplateString string
+		expectBodyContent bool
+	}{
+		{
+			name:              "GET request should have body with template",
+			method:            http.MethodGet,
+			banTemplateString: "<html>You are banned</html>",
+			expectBodyContent: true,
+		},
+		{
+			name:              "HEAD request should NOT have body even with template",
+			method:            http.MethodHead,
+			banTemplateString: "<html>You are banned</html>",
+			expectBodyContent: false,
+		},
+		{
+			name:              "POST request should have body with template",
+			method:            http.MethodPost,
+			banTemplateString: "<html>You are banned</html>",
+			expectBodyContent: true,
+		},
+		{
+			name:              "PUT request should have body with template",
+			method:            http.MethodPut,
+			banTemplateString: "<html>You are banned</html>",
+			expectBodyContent: true,
+		},
+		{
+			name:              "DELETE request should have body with template",
+			method:            http.MethodDelete,
+			banTemplateString: "<html>You are banned</html>",
+			expectBodyContent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bouncer := &Bouncer{
+				remediationStatusCode:   403,
+				remediationCustomHeader: "X-Test-Remediation",
+				banTemplateString:       tt.banTemplateString,
+			}
+
+			rw := httptest.NewRecorder()
+			handleBanServeHTTP(bouncer, rw, tt.method)
+
+			// Check status code
+			if rw.Code != 403 {
+				t.Errorf("Expected status code 403, got %d", rw.Code)
+			}
+
+			// Check custom header
+			headerValue := rw.Header().Get("X-Test-Remediation")
+			if headerValue != "ban" {
+				t.Errorf("Expected header X-Test-Remediation to be 'ban', got %s", headerValue)
+			}
+
+			// Check body content
+			body := rw.Body.String()
+			hasBodyContent := len(body) > 0
+
+			if hasBodyContent != tt.expectBodyContent {
+				t.Errorf("Method %s: expected body content: %v, got body content: %v (body: %q)",
+					tt.method, tt.expectBodyContent, hasBodyContent, body)
+			}
+
+			// If we expect body content, verify it matches template
+			if tt.expectBodyContent && body != tt.banTemplateString {
+				t.Errorf("Expected body %q, got %q", tt.banTemplateString, body)
+			}
+		})
+	}
+}
+
+func TestCaptchaMethodBasedLogic(t *testing.T) {
+	tests := []struct {
+		name              string
+		method            string
+		remediation       string
+		expectBanFallback bool
+	}{
+		{
+			name:              "GET with captcha remediation should allow captcha",
+			method:            http.MethodGet,
+			remediation:       cache.CaptchaValue,
+			expectBanFallback: false,
+		},
+		{
+			name:              "HEAD with captcha remediation should fallback to ban",
+			method:            http.MethodHead,
+			remediation:       cache.CaptchaValue,
+			expectBanFallback: true,
+		},
+		{
+			name:              "POST with captcha remediation should allow captcha",
+			method:            http.MethodPost,
+			remediation:       cache.CaptchaValue,
+			expectBanFallback: false,
+		},
+		{
+			name:              "PUT with captcha remediation should fallback to ban",
+			method:            http.MethodPut,
+			remediation:       cache.CaptchaValue,
+			expectBanFallback: true,
+		},
+		{
+			name:              "DELETE with captcha remediation should fallback to ban",
+			method:            http.MethodDelete,
+			remediation:       cache.CaptchaValue,
+			expectBanFallback: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test the core logic: should we use captcha or fallback to ban?
+			shouldUseCaptcha := tt.remediation == cache.CaptchaValue && (tt.method == http.MethodGet || tt.method == http.MethodPost)
+
+			if shouldUseCaptcha == tt.expectBanFallback {
+				t.Errorf("Method %s with %s remediation: expected ban fallback %v, but logic would use captcha %v",
+					tt.method, tt.remediation, tt.expectBanFallback, shouldUseCaptcha)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #254

This PR introduces two changes:

* Ban remediation body is not writen for HEAD requests
* For HEAD requests fallback to BAN instead of Captcha

Both with test coverage.