### PR TITLE
✨️ Do not block middleware startup due to stream intialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,11 @@ make run
   - int64
   - default: 0
   - Used only in `stream` and `alone` mode, the maximum number of time we can not reach Crowdsec before blocking traffic (set -1 to never block)
+- StreamStartupBlock
+  - bool
+  - default: true
+  - Used only in `stream` and `alone` mode, controls whether the initial stream update runs synchronously (blocking) or asynchronously during plugin initialization
+  - **Warning**: When `true`, Traefik availability might be impacted during startup as the plugin waits for the initial CrowdSec data fetch to complete
 - DefaultDecisionSeconds
   - int64
   - default: 60
@@ -545,6 +550,7 @@ http:
           LogFilePath: ""
           updateIntervalSeconds: 60
           updateMaxFailure: 0
+          streamStartupBlock: true
           defaultDecisionSeconds: 60
           remediationStatusCode: 403
           httpTimeoutSeconds: 10

--- a/bouncer.go
+++ b/bouncer.go
@@ -620,7 +620,9 @@ func handleStreamCache(bouncer *Bouncer) error {
 		bouncer.cacheClient.Delete(decision.Value)
 	}
 	bouncer.log.Debug("handleStreamCache:updated")
-	isCrowdsecStreamStartup = false
+	if isCrowdsecStreamStartup {
+		isCrowdsecStreamStartup = false
+	}
 	return nil
 }
 

--- a/bouncer.go
+++ b/bouncer.go
@@ -590,7 +590,7 @@ func handleStreamCache(bouncer *Bouncer) error {
 		Scheme:   bouncer.crowdsecScheme,
 		Host:     bouncer.crowdsecHost,
 		Path:     bouncer.crowdsecPath + bouncer.crowdsecStreamRoute,
-		RawQuery: fmt.Sprintf("startup=%t", !isCrowdsecStreamHealthy || !isCrowdsecStreamStartup),
+		RawQuery: fmt.Sprintf("startup=%t", !isCrowdsecStreamHealthy || isCrowdsecStreamStartup),
 	}
 	body, err := crowdsecQuery(bouncer, streamRouteURL.String(), nil)
 	if err != nil {

--- a/bouncer.go
+++ b/bouncer.go
@@ -62,7 +62,7 @@ const (
 
 //nolint:gochecknoglobals
 var (
-	isStartup               = true
+	lapiStreamInitialized   = false
 	isCrowdsecStreamHealthy = true
 	updateFailure           int64
 	streamTicker            chan bool
@@ -262,8 +262,6 @@ func New(_ context.Context, next http.Handler, config *configuration.Config, nam
 				return nil, err
 			}
 		}
-		handleStreamTicker(bouncer)
-		isStartup = false
 		streamTicker = startTicker("stream", config.UpdateIntervalSeconds, log, func() {
 			handleStreamTicker(bouncer)
 		})
@@ -584,7 +582,7 @@ func handleStreamCache(bouncer *Bouncer) error {
 		Scheme:   bouncer.crowdsecScheme,
 		Host:     bouncer.crowdsecHost,
 		Path:     bouncer.crowdsecPath + bouncer.crowdsecStreamRoute,
-		RawQuery: fmt.Sprintf("startup=%t", !isCrowdsecStreamHealthy || isStartup),
+		RawQuery: fmt.Sprintf("startup=%t", !isCrowdsecStreamHealthy || !lapiStreamInitialized),
 	}
 	body, err := crowdsecQuery(bouncer, streamRouteURL.String(), nil)
 	if err != nil {
@@ -614,6 +612,7 @@ func handleStreamCache(bouncer *Bouncer) error {
 		bouncer.cacheClient.Delete(decision.Value)
 	}
 	bouncer.log.Debug("handleStreamCache:updated")
+	lapiStreamInitialized = true
 	return nil
 }
 
@@ -723,6 +722,12 @@ func appsecQuery(bouncer *Bouncer, ip string, httpReq *http.Request) error {
 func reportMetrics(bouncer *Bouncer) error {
 	now := time.Now()
 	currentCount := atomic.LoadInt64(&blockedRequests)
+
+	// Initialize lastMetricsPush if it's zero value
+	if lastMetricsPush.IsZero() {
+		lastMetricsPush = now
+	}
+
 	windowSizeSeconds := int(now.Sub(lastMetricsPush).Seconds())
 
 	bouncer.log.Debug(fmt.Sprintf("reportMetrics: blocked_requests=%d window_size=%ds", currentCount, windowSizeSeconds))

--- a/bouncer.go
+++ b/bouncer.go
@@ -269,8 +269,6 @@ func New(_ context.Context, next http.Handler, config *configuration.Config, nam
 
 	// Start metrics ticker if not already running
 	if metricsTicker == nil && config.MetricsUpdateIntervalSeconds > 0 {
-		lastMetricsPush = time.Now() // Initialize lastMetricsPush when starting the metrics ticker
-		handleMetricsTicker(bouncer)
 		metricsTicker = startTicker("metrics", config.MetricsUpdateIntervalSeconds, log, func() {
 			handleMetricsTicker(bouncer)
 		}, false)

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -69,6 +69,7 @@ type Config struct {
 	UpdateIntervalSeconds                    int64    `json:"updateIntervalSeconds,omitempty"`
 	MetricsUpdateIntervalSeconds             int64    `json:"metricsUpdateIntervalSeconds,omitempty"`
 	UpdateMaxFailure                         int64    `json:"updateMaxFailure,omitempty"`
+	StreamStartupBlock                       bool     `json:"streamStartupBlock,omitempty"`
 	DefaultDecisionSeconds                   int64    `json:"defaultDecisionSeconds,omitempty"`
 	RemediationStatusCode                    int      `json:"remediationStatusCode,omitempty"`
 	HTTPTimeoutSeconds                       int64    `json:"httpTimeoutSeconds,omitempty"`
@@ -126,6 +127,7 @@ func New() *Config {
 		UpdateIntervalSeconds:          60,
 		MetricsUpdateIntervalSeconds:   600,
 		UpdateMaxFailure:               0,
+		StreamStartupBlock:             true,
 		DefaultDecisionSeconds:         60,
 		RemediationStatusCode:          http.StatusForbidden,
 		HTTPTimeoutSeconds:             10,


### PR DESCRIPTION
Fixes #252

This PR fixes the fact that during middleware startup in Stream mode... until the stream initializes (or fails) the whole middleware (and traefik!) startup is blocked synchronously.

From my experience, on out of the box setups where you are using a local db instead of mysql/postgre/mariadb stream initial sinchronization can take between 30 and 50 seconds. With mysql this is at most 2-3 seconds.

**Concern**: there might be a small time window in wich the stream is not available after the middleware is "ready". The results of requests during that time window are governed by UpdateMaxFailure. If UpdateMaxFailure=0 after the middleware starts, responses will be blocked until the stream initializes.

I was thinking of preserving previous behaviour if UpdateMaxFailure=0, but I cannot think of situation in which someone would want Traefik to hold initilization for +30 seconds becoming totally unresponsive (the Traefik pod reports as healthy, even if the middlewares are not initialized).
