### PR TITLE
docs: fix wicketkeeper name references

### DIFF
--- a/examples/custom-captcha/README.md
+++ b/examples/custom-captcha/README.md
@@ -5,7 +5,7 @@ Read the example captcha before this, to better understand what is done here.
 ### Traefik configuration
 
 The minimal configuration is defined below to implement custom captcha.  
-This documentation use https://github.com/a-ve/wicketpeeker, a self-hosted captcha provider that have a similar API than big providers.
+This documentation use https://github.com/a-ve/wicketkeeper, a self-hosted captcha provider that have a similar API than big providers.
 
 Minimal API requirement:
 

--- a/examples/custom-captcha/docker-compose.yml
+++ b/examples/custom-captcha/docker-compose.yml
@@ -94,10 +94,10 @@ services:
     labels:
       - "traefik.enable=true"
       # Definition of the router
-      - "traefik.http.routers.router-wicketpeeker.rule=Host(`captcha.localhost`)"
-      - "traefik.http.routers.router-wicketpeeker.entrypoints=web"
+      - "traefik.http.routers.router-wicketkeeper.rule=Host(`captcha.localhost`)"
+      - "traefik.http.routers.router-wicketkeeper.entrypoints=web"
       # Definition of the service
-      - "traefik.http.services.service-whitekeeper.loadbalancer.server.port=8080"
+      - "traefik.http.services.service-wicketkeeper.loadbalancer.server.port=8080"
     depends_on:
       - redis
 


### PR DESCRIPTION
When testing out wicketkeeper as a captcha provider, I found a few small typos. The provided example/demo docker compose worked great though!