### PR TITLE
Add support for injecting request header value into ban HTML template

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ make run
   - string
   - default: ""
   - Path where the ban html file is stored (default empty ""=disabled)
-- TraceCustomHeader
+- TraceHeadersCustomName
   - string
   - default: ""
   - Request Header name whose value to inject in ban HTML response (default empty ""=disabled)
@@ -607,7 +607,7 @@ http:
           captchaGracePeriodSeconds: 1800
           captchaHTMLFilePath: /captcha.html
           banHTMLFilePath: /ban.html
-          traceCustomHeader: X-Request-ID
+          traceHeadersCustomName: X-Request-ID
           metricsUpdateIntervalSeconds: 600
 ```
 

--- a/bouncer.go
+++ b/bouncer.go
@@ -194,7 +194,7 @@ func New(_ context.Context, next http.Handler, config *configuration.Config, nam
 		remediationStatusCode:   config.RemediationStatusCode,
 		redisUnreachableBlock:   config.RedisCacheUnreachableBlock,
 		banTemplate:             banTemplate,
-		traceCustomHeader:       config.TraceCustomHeader,
+		traceCustomHeader:       config.TraceHeadersCustomName,
 		crowdsecStreamRoute:     crowdsecStreamRoute,
 		crowdsecHeader:          crowdsecHeader,
 		log:                     log,
@@ -411,8 +411,9 @@ func (bouncer *Bouncer) handleBanServeHTTP(rw http.ResponseWriter, req *http.Req
 
 	if bouncer.traceCustomHeader != "" {
 		headerVal := req.Header.Get(bouncer.traceCustomHeader)
+
 		if headerVal != "" {
-			templateData["CustomHeader"] = headerVal
+			templateData["TraceID"] = headerVal
 		}
 	}
 

--- a/examples/custom-ban-page/README.md
+++ b/examples/custom-ban-page/README.md
@@ -54,6 +54,6 @@ In the html of the ban page, you can use:
 ```
 <script>var remediation = "{{ .RemediationReason }}"</script>
 <script>var clientIp = "{{ .ClientIP }}"</script>
-<script>var customHeader = "{{ .CustomHeader }}"</script>
+<script>var traceID = "{{ .TraceID }}"</script>
 ```
 With the above tweak and some other js, you can customize your ban page on runtime.

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -86,7 +86,7 @@ type Config struct {
 	RedisCacheDatabase                       string   `json:"redisCacheDatabase,omitempty"`
 	RedisCacheUnreachableBlock               bool     `json:"redisCacheUnreachableBlock,omitempty"`
 	BanHTMLFilePath                          string   `json:"banHtmlFilePath,omitempty"`
-	TraceCustomHeader                        string   `json:"traceCustomHeader,omitempty"`
+	TraceHeadersCustomName                   string   `json:"traceHeadersCustomName,omitempty"`
 	CaptchaHTMLFilePath                      string   `json:"captchaHtmlFilePath,omitempty"`
 	CaptchaProvider                          string   `json:"captchaProvider,omitempty"`
 	CaptchaCustomJsURL                       string   `json:"captchaCustomJsUrl,omitempty"`


### PR DESCRIPTION
## Overview

Adds a parameter `displayRequestHeader` where you can specify a request header to whose value can be injected into the ban HTML template via `.CustomHeader`.

## Why

<img width="850" height="413" alt="image" src="https://github.com/user-attachments/assets/80391b49-6342-47aa-b537-55614967c796" />

A use-case would be to emulate the feature like with Cloudflare where a user who is blocked has a `Cloudflare Ray ID`.

How this would work with Traefik+Crowdsec is by having Traefik appending a request header like `X-Trace-ID` or `X-Request-ID` (for example: https://github.com/trinnylondon/traefik-add-trace-id). This would allow users to contact website administrators, in case they believe they have been wrongfully blocked, using the provided ID that would help administrators easily track it down. 

