### PR TITLE
🔒️ Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Main
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/security/code-scanning/8](https://github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/security/code-scanning/8)

In general, to fix this issue you should explicitly declare a `permissions` block for the workflow or for the specific job, granting only the minimal permissions needed. Since this job only checks out code, caches dependencies, and runs local Go tooling and tests, it does not appear to need any write permissions; `contents: read` is sufficient and aligns with the recommendation given by CodeQL.

The best fix without changing existing functionality is to add a `permissions` section at the workflow root (top level), right after `name: Main` and before the `on:` block. This will apply to all jobs (including `main`) that do not define their own `permissions` block. The new block should be:

```yaml
permissions:
  contents: read
```

Concretely, edit `.github/workflows/main.yml` at the top of the file: after line 1 (`name: Main`) insert the `permissions` block, shifting the existing `on:` section down. No additional imports or definitions are required; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
