### PR TITLE
cicd(versioning): Automate proper version tagging in the bouncer.go that is reported to Crowdsec LAPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,20 +25,20 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-      - name: Update version in bouncer.go
+      - name: Update version in version.go
         run: |
-          sed -i 's/pluginVersion *= *"[^"]*"/pluginVersion           = "'"${{ steps.get_version.outputs.version }}"'"/' bouncer.go
+          sed -i 's/pluginVersion = "[^"]*"/pluginVersion = "'"${{ steps.get_version.outputs.version }}"'"/' version.go
 
       - name: Verify change
         run: |
           echo "Updated version to ${{ steps.get_version.outputs.version }}"
-          grep 'pluginVersion' bouncer.go
+          cat version.go
 
       - name: Commit, push, and retag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add bouncer.go
+          git add version.go
           if git diff --cached --quiet; then
             echo "Version already up to date, nothing to commit"
             exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release Version Update
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-version:
+    name: Update version in source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Extract version from tag
+        id: get_version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Update version in bouncer.go
+        run: |
+          sed -i 's/pluginVersion *= *"[^"]*"/pluginVersion           = "'"${{ steps.get_version.outputs.version }}"'"/' bouncer.go
+
+      - name: Verify change
+        run: |
+          echo "Updated version to ${{ steps.get_version.outputs.version }}"
+          grep 'pluginVersion' bouncer.go
+
+      - name: Commit, push, and retag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bouncer.go
+          if git diff --cached --quiet; then
+            echo "Version already up to date, nothing to commit"
+            exit 0
+          fi
+          git commit -m "chore: bump version to ${{ steps.get_version.outputs.version }}"
+          git push origin main
+          # Move the release tag to include the version update
+          git tag -f "${{ steps.get_version.outputs.tag }}"
+          git push -f origin "${{ steps.get_version.outputs.tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,6 @@ jobs:
       - name: Update version in version.go
         run: |
           sed -i 's/pluginVersion = "[^"]*"/pluginVersion = "'"${{ steps.get_version.outputs.version }}"'"/' version.go
-
-      - name: Verify change
-        run: |
-          echo "Updated version to ${{ steps.get_version.outputs.version }}"
           cat version.go
 
       - name: Commit, push, and retag
@@ -43,7 +39,7 @@ jobs:
             echo "Version already up to date, nothing to commit"
             exit 0
           fi
-          git commit -m "chore: bump version to ${{ steps.get_version.outputs.version }}"
+          git commit -m "⬆️ chore: bump version to ${{ steps.get_version.outputs.version }}"
           git push origin main
           # Move the release tag to include the version update
           git tag -f "${{ steps.get_version.outputs.tag }}"

--- a/bouncer.go
+++ b/bouncer.go
@@ -63,6 +63,7 @@ const (
 
 //nolint:gochecknoglobals
 var (
+	pluginVersion           = "1.5.0"
 	isStartup               = true
 	isCrowdsecStreamHealthy = true
 	updateFailure           int64
@@ -674,7 +675,7 @@ func crowdsecQuery(bouncer *Bouncer, stringURL string, data []byte) ([]byte, err
 		req, _ = http.NewRequest(http.MethodGet, stringURL, nil)
 	}
 	req.Header.Add(bouncer.crowdsecHeader, bouncer.crowdsecKey)
-	req.Header.Add("User-Agent", "Crowdsec-Bouncer-Traefik-Plugin/1.X.X")
+	req.Header.Add("User-Agent", "Crowdsec-Bouncer-Traefik-Plugin/"+pluginVersion)
 
 	res, err := bouncer.httpClient.Do(req)
 	if err != nil {
@@ -779,7 +780,7 @@ func reportMetrics(bouncer *Bouncer) error {
 	metrics := map[string]interface{}{
 		"remediation_components": []map[string]interface{}{
 			{
-				"version": "1.X.X",
+				"version": pluginVersion,
 				"type":    "bouncer",
 				"name":    "traefik_plugin",
 				"metrics": []map[string]interface{}{

--- a/bouncer.go
+++ b/bouncer.go
@@ -63,7 +63,6 @@ const (
 
 //nolint:gochecknoglobals
 var (
-	pluginVersion           = "1.5.0"
 	isStartup               = true
 	isCrowdsecStreamHealthy = true
 	updateFailure           int64

--- a/version.go
+++ b/version.go
@@ -1,0 +1,4 @@
+package crowdsec_bouncer_traefik_plugin //nolint:revive,stylecheck
+
+// pluginVersion is updated automatically by the release workflow.
+var pluginVersion = "1.5.0"

--- a/version.go
+++ b/version.go
@@ -1,5 +1,4 @@
 package crowdsec_bouncer_traefik_plugin //nolint:revive,stylecheck
 
 // pluginVersion is updated automatically by the release workflow.
-//nolint:gochecknoglobals
-var pluginVersion = "1.5.0"
+var pluginVersion = "1.5.0" //nolint:gochecknoglobals

--- a/version.go
+++ b/version.go
@@ -1,4 +1,5 @@
 package crowdsec_bouncer_traefik_plugin //nolint:revive,stylecheck
 
 // pluginVersion is updated automatically by the release workflow.
+//nolint:gochecknoglobals
 var pluginVersion = "1.5.0"


### PR DESCRIPTION
In reference to https://github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/pull/287 - this is an automatic way. Works fine on my forked repo. I hope it will finally report a correct version so I can know which machines to update at a glance :)