### PR TITLE
feat: add EU CAPTCHA as a first-class captcha provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The following captcha providers are supported now:
 - [hcaptcha](https://www.hcaptcha.com/)
 - [recaptcha](https://www.google.com/recaptcha/about/)
 - [turnstile](https://www.cloudflare.com/products/turnstile/)
+- [eucaptcha](https://eu-captcha.eu/) — GDPR-compliant, EU-hosted
 - [custom/wicketkeeper](https://github.com/a-ve/wicketkeeper)
 
 There are 5 operating modes (CrowdsecMode) for this plugin:
@@ -480,7 +481,7 @@ make run
   - Used only in `alone` mode, scenarios for Crowdsec CAPI
 - CaptchaProvider
   - string
-  - Provider to validate the captcha, expected values are: `hcaptcha`, `recaptcha`, `turnstile` or `custom`
+  - Provider to validate the captcha, expected values are: `hcaptcha`, `recaptcha`, `turnstile`, `eucaptcha` or `custom`
 - CaptchaCustomJsURL
   - string
   - If CaptchaProvider is `custom`, URL used to load the challenge in the HTML (in case of hcaptcha: `https://hcaptcha.com/1/api.js`)
@@ -621,6 +622,12 @@ http:
           captchaSecretKey: FIXME
           captchaGracePeriodSeconds: 1800
           captchaHTMLFilePath: /captcha.html
+          # EU CAPTCHA (GDPR-compliant, EU-hosted alternative):
+          # captchaProvider: eucaptcha
+          # captchaSiteKey: FIXME
+          # captchaSecretKey: FIXME
+          # captchaGracePeriodSeconds: 1800
+          # captchaHTMLFilePath: /captcha.html
           banHTMLFilePath: /ban.html
           traceHeadersCustomName: X-Request-ID
           metricsUpdateIntervalSeconds: 600

--- a/examples/captcha/README.md
+++ b/examples/captcha/README.md
@@ -7,10 +7,11 @@ This plugins support the `ban` and `captcha` remediation.
 ### Traefik configuration
 
 The minimal configuration is defined below.  
-For now 3 captcha providers are supported:  
+For now 4 captcha providers are supported:
  - [hcaptcha](https://www.hcaptcha.com/)
  - [recaptcha](https://www.google.com/recaptcha/about/)
  - [turnstile](https://www.cloudflare.com/fr-fr/products/turnstile/)
+ - [eucaptcha](https://eu-captcha.eu/) — GDPR-compliant, EU-hosted
 
 ```yaml
   labels:
@@ -156,6 +157,23 @@ Choose v2 (challenge) and configure the domain to protect:
 
 TODO
 
-- Hcatpcha
+- Hcaptcha
 
 TODO
+
+- EU CAPTCHA
+
+Sign up at [app.eu-captcha.eu](https://app.eu-captcha.eu), create a sitekey for your domain, and use `eucaptcha` as the provider:
+
+```yaml
+captchaProvider: eucaptcha
+captchaSiteKey: <your-sitekey>      # public key shown in the widget
+captchaSecretKey: <your-secret>     # private key used for server-side verification
+captchaGracePeriodSeconds: 1800
+captchaHTMLFilePath: /captcha.html
+```
+
+EU CAPTCHA is a GDPR-compliant, privacy-first anti-bot service hosted entirely within the EU.
+Unlike other providers it sends additional context (client IP and user agent) to the verification endpoint,
+and returns a `train` flag alongside `success`; a `train: true` response is treated as a failure and
+the challenge is shown again.

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -38,6 +38,7 @@ const (
 	RecaptchaProvider = "recaptcha"
 	TurnstileProvider = "turnstile"
 	CustomProvider    = "custom"
+	EucaptchaProvider = "eucaptcha"
 )
 
 // Config the plugin configuration.
@@ -376,8 +377,8 @@ func validateParamsIPs(listIP []string, key string) error {
 }
 
 func validateCaptcha(config *Config) error {
-	if !contains([]string{"", HcaptchaProvider, RecaptchaProvider, TurnstileProvider, CustomProvider}, config.CaptchaProvider) {
-		return fmt.Errorf("CaptchaProvider: must be one of '%s', '%s', '%s' or '%s'", HcaptchaProvider, RecaptchaProvider, TurnstileProvider, CustomProvider)
+	if !contains([]string{"", HcaptchaProvider, RecaptchaProvider, TurnstileProvider, CustomProvider, EucaptchaProvider}, config.CaptchaProvider) {
+		return fmt.Errorf("CaptchaProvider: must be one of '%s', '%s', '%s', '%s' or '%s'", HcaptchaProvider, RecaptchaProvider, TurnstileProvider, CustomProvider, EucaptchaProvider)
 	}
 	if config.CaptchaProvider == CustomProvider {
 		if config.CaptchaCustomKey == "" || config.CaptchaCustomResponse == "" || config.CaptchaCustomValidateURL == "" || config.CaptchaCustomJsURL == "" {


### PR DESCRIPTION
EU CAPTCHA (eu-captcha.eu) is a GDPR-compliant, privacy-first anti-bot service hosted entirely within the EU. This commit adds it as a native provider alongside hcaptcha, recaptcha, and turnstile.

Key differences from existing providers that required code changes:

- Verification uses a JSON body instead of form-encoding, and must include sitekey, client_ip, and client_user_agent in addition to the token and secret.
- At startup, sitekey/secret validity is checked via the dedicated /verify-credentials endpoint and the result is logged.

Changes:
- pkg/configuration/configuration.go: add EucaptchaProvider constant; include it in the validateCaptcha allowlist.
- pkg/captcha/captcha.go: register eucaptcha in infoProviders (including credentialsCheck URL); extend Validate() to accept remoteIP so client context can be forwarded; extract validateEucaptcha() for the JSON verification path; add checkEucaptchaCredentials() for startup credential probing; update ServeHTTP() call accordingly. All existing providers are unaffected.
- README.md, examples/captcha/README.md: document the new provider.

Configuration:
  captchaProvider: eucaptcha
  captchaSiteKey: <public sitekey from app.eu-captcha.eu>
  captchaSecretKey: <secret key from app.eu-captcha.eu>
  captchaGracePeriodSeconds: 1800 captchaHTMLFilePath: /captcha.html