### PR TITLE
⬆️ chore: bump go.mod to go 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin
 
-go 1.22
+go 1.23
 
 require (
 	github.com/leprosus/golang-ttl-map v1.1.7


### PR DESCRIPTION
Align the module's declared Go version with what the project actually uses.

## Why
- `go.mod` declared `go 1.22`, but CI (`main.yml`) already builds and tests on **1.23**, and the README "go.mod Go version" badge advertises whatever `go.mod` says. So the advertised/declared minimum (1.22) was never the version CI exercised — a silent divergence that keeps drifting.
- This bumps the declared version to **1.23** so CI tests the advertised minimum and everything lines up on one version.

## Verification (Go 1.23, `GOTOOLCHAIN=local`)
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅
- `go mod verify` → all modules verified ✅
- One-line diff, no `toolchain` line added, no vendor change.

The README badge will reflect 1.23 automatically once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)