### PR TITLE
📝 docs: fix Mermaid diagrams not rendering (lowercase destroy keyword)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ sequenceDiagram
     User->>TraefikPlugin: Can I access that webpage
     create participant CrowdsecLAPI
     TraefikPlugin-->>CrowdsecLAPI: Does the User IP has a Crowdsec Decision ?
-    Destroy CrowdsecLAPI
+    destroy CrowdsecLAPI
     CrowdsecLAPI-->>TraefikPlugin: Yes a ban Decision
     TraefikPlugin->>User: No, HTTP 403
 ```
@@ -82,9 +82,9 @@ sequenceDiagram
     User->>TraefikPlugin: Can I access that webpage
     create participant CrowdsecLAPI
     TraefikPlugin-->>CrowdsecLAPI: Does the User IP has a crowdsec decision ?
-    Destroy CrowdsecLAPI
+    destroy CrowdsecLAPI
     CrowdsecLAPI-->>TraefikPlugin: Nothing, all good!
-    Destroy TraefikPlugin
+    destroy TraefikPlugin
     TraefikPlugin->>Webserver: Forwarding this HTTP Request from User
     Webserver->>User: HTTP Response
 ```
@@ -105,10 +105,10 @@ sequenceDiagram
     PluginCache-->>TraefikPlugin: Nothing, all good!
     create participant CrowdsecLAPI
     TraefikPlugin-->>CrowdsecLAPI: Does the User IP has a crowdsec decision ?
-    Destroy CrowdsecLAPI
+    destroy CrowdsecLAPI
     CrowdsecLAPI-->>TraefikPlugin: Yes a ban Decision
     TraefikPlugin-->>PluginCache: Store the information for this IP for DefaultDecisionSeconds
-    Destroy PluginCache
+    destroy PluginCache
     PluginCache-->>TraefikPlugin: Done
     TraefikPlugin->>User: No, HTTP 403
 ```
@@ -125,10 +125,10 @@ sequenceDiagram
     PluginCache-->>TraefikPlugin: Nothing, all good!
     create participant CrowdsecLAPI
     TraefikPlugin-->>CrowdsecLAPI: Does the User IP has a crowdsec decision ?
-    Destroy CrowdsecLAPI
+    destroy CrowdsecLAPI
     CrowdsecLAPI-->>TraefikPlugin: Nothing, all good!
     TraefikPlugin-->>PluginCache: Store the information for this IP for DefaultDecisionSeconds
-    Destroy PluginCache
+    destroy PluginCache
     PluginCache-->>TraefikPlugin: Done
     TraefikPlugin->>Webserver: Forwarding this HTTP Request from User
     Webserver->>User: HTTP Response
@@ -145,11 +145,11 @@ sequenceDiagram
     participant TraefikPlugin
     participant CrowdsecLAPI
     TraefikPlugin->>CrowdsecLAPI: What are the current decisions
-    Destroy CrowdsecLAPI
+    destroy CrowdsecLAPI
     CrowdsecLAPI->>TraefikPlugin: Here is the list
     create participant PluginCache
     TraefikPlugin-->>PluginCache: Store this list
-    Destroy PluginCache
+    destroy PluginCache
     PluginCache-->>TraefikPlugin: Done
 ```
 
@@ -162,9 +162,9 @@ sequenceDiagram
     User->>TraefikPlugin: Can I access that webpage
     create participant PluginCache
     TraefikPlugin-->>PluginCache: Does the User IP has a crowdsec decision ?
-    Destroy PluginCache
+    destroy PluginCache
     PluginCache-->>TraefikPlugin: Yes a ban decision
-    Destroy TraefikPlugin
+    destroy TraefikPlugin
     TraefikPlugin->>User: No, HTTP 403
 ```
 
@@ -177,9 +177,9 @@ sequenceDiagram
     User->>TraefikPlugin: Can I access that webpage
     create participant PluginCache
     TraefikPlugin-->>PluginCache: Does the User IP has a crowdsec decision ?
-    Destroy PluginCache
+    destroy PluginCache
     PluginCache-->>TraefikPlugin: Nothing, all good!
-    Destroy TraefikPlugin
+    destroy TraefikPlugin
     TraefikPlugin->>Webserver: Forwarding this HTTP Request from User
     Webserver->>User: HTTP Response
 ```
@@ -195,11 +195,11 @@ sequenceDiagram
     participant TraefikPlugin
     participant CrowdsecCAPI
     TraefikPlugin->>CrowdsecCAPI: What are the current decisions from CAPI
-    Destroy CrowdsecCAPI
+    destroy CrowdsecCAPI
     CrowdsecCAPI->>TraefikPlugin: Here is the list
     create participant PluginCache
     TraefikPlugin-->>PluginCache: Store this list
-    Destroy PluginCache
+    destroy PluginCache
     PluginCache-->>TraefikPlugin: Done
 ```
 
@@ -212,9 +212,9 @@ sequenceDiagram
     User->>TraefikPlugin: Can I access that webpage
     create participant PluginCache
     TraefikPlugin-->>PluginCache: Does the User IP has a crowdsec decision ?
-    Destroy PluginCache
+    destroy PluginCache
     PluginCache-->>TraefikPlugin: Yes a ban decision
-    Destroy TraefikPlugin
+    destroy TraefikPlugin
     TraefikPlugin->>User: No, HTTP 403
 ```
 
@@ -227,9 +227,9 @@ sequenceDiagram
     User->>TraefikPlugin: Can I access that webpage
     create participant PluginCache
     TraefikPlugin-->>PluginCache: Does the User IP has a crowdsec decision ?
-    Destroy PluginCache
+    destroy PluginCache
     PluginCache-->>TraefikPlugin: Nothing, all good!
-    Destroy TraefikPlugin
+    destroy TraefikPlugin
     TraefikPlugin->>Webserver: Forwarding this HTTP Request from User
     Webserver->>User: HTTP Response
 ```
@@ -247,9 +247,9 @@ sequenceDiagram
     User->>TraefikPlugin: Can I access that webpage
     create participant CrowdsecAppSec
     TraefikPlugin-->>CrowdsecAppSec: Is this request malicious ?
-    Destroy CrowdsecAppSec
+    destroy CrowdsecAppSec
     CrowdsecAppSec-->>TraefikPlugin: Yes I think so
-    Destroy TraefikPlugin
+    destroy TraefikPlugin
     TraefikPlugin->>User: No, HTTP 403
 ```
 
@@ -262,9 +262,9 @@ sequenceDiagram
     User->>TraefikPlugin: Can I access that webpage
     create participant CrowdsecAppSec
     TraefikPlugin-->>CrowdsecAppSec: Is this request malicious ?
-    Destroy CrowdsecAppSec
+    destroy CrowdsecAppSec
     CrowdsecAppSec-->>TraefikPlugin: No I don't think so
-    Destroy TraefikPlugin
+    destroy TraefikPlugin
     TraefikPlugin->>Webserver: Forwarding this HTTP Request from User
     Webserver->>User: HTTP Response
 ```
@@ -285,12 +285,12 @@ sequenceDiagram
     User->>TraefikPlugin: Fine, done!
     create participant ProviderCaptcha
     TraefikPlugin-->>ProviderCaptcha: Is the validation OK ?
-    Destroy ProviderCaptcha
+    destroy ProviderCaptcha
     ProviderCaptcha-->>TraefikPlugin: Yes
     TraefikPlugin-->>PluginCache: Set the User IP Clean for captchaGracePeriodSeconds
-    Destroy PluginCache
+    destroy PluginCache
     PluginCache-->>TraefikPlugin: Done
-    Destroy TraefikPlugin
+    destroy TraefikPlugin
     TraefikPlugin->>Webserver: Forwarding this HTTP Request from User
     Webserver->>User: HTTP Response
 ```

--- a/examples/captcha/README.md
+++ b/examples/captcha/README.md
@@ -100,9 +100,9 @@ sequenceDiagram
     User->>TraefikPlugin: Can I access that webpage
     create participant PluginCache
     TraefikPlugin-->>PluginCache: Does the user IP has a crowdsec decision ?
-    Destroy PluginCache
+    destroy PluginCache
     PluginCache-->>TraefikPlugin: Nothing, all good!
-    Destroy TraefikPlugin
+    destroy TraefikPlugin
     TraefikPlugin->>Webserver: Forwarding this HTTP Request from User
     Webserver->>User: HTTP Response
 ```
@@ -121,12 +121,12 @@ sequenceDiagram
     User->>TraefikPlugin: Fine, done!
     create participant ProviderCaptcha
     TraefikPlugin-->>ProviderCaptcha: Is the validation OK ?
-    Destroy ProviderCaptcha    
+    destroy ProviderCaptcha    
     ProviderCaptcha-->>TraefikPlugin: Yes
     TraefikPlugin-->>PluginCache: Set the User IP Clean for captchaGracePeriodSeconds
-    Destroy PluginCache
+    destroy PluginCache
     PluginCache-->>TraefikPlugin: Done
-    Destroy TraefikPlugin
+    destroy TraefikPlugin
     TraefikPlugin->>Webserver: Forwarding this HTTP Request from User
     Webserver->>User: HTTP Response
 ```
@@ -140,7 +140,7 @@ sequenceDiagram
     User->>TraefikPlugin: Can I access that webpage
     create participant PluginCache
     TraefikPlugin-->>PluginCache: Does the User IP has a Crowdsec Decision ?
-    Destroy PluginCache
+    destroy PluginCache
     PluginCache-->>TraefikPlugin: Yes a ban Decision
     TraefikPlugin->>User: No, HTTP 403
 ```


### PR DESCRIPTION
## Problem

The README sequence diagrams (and the captcha example README) don't render on GitHub — closes #270.

## Root cause

The diagrams used the keyword `Destroy` (capital D). Mermaid keywords are **case-sensitive**; the valid keyword is lowercase `destroy`. A single invalid token aborts parsing of the entire diagram, and since every diagram contained at least one `Destroy`, they all failed to render. The companion `create` keyword was already correct.

This wasn't a GitHub policy change — the syntax was always invalid; GitHub's Mermaid renderer just rejects it.

## Fix

Lowercased every `Destroy` → `destroy`:
- `README.md` — 26 occurrences across all 13 diagrams (none/live/stream/alone/appsec/captcha modes)
- `examples/captcha/README.md` — 6 occurrences across 3 diagrams

Left the prose `#### Destroy the VM` in `examples/binary-vm/README.md` untouched (not Mermaid).

## Verification

Audited all diagrams against Mermaid's grammar rules:
- every `create participant X` is immediately followed by a message with **X as receiver** ✓
- every `destroy X` is adjacent to a message where **X is sender or receiver** ✓
- no participant is referenced after being destroyed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)