### PR TITLE
🐛 ci(renovate): fix OOM crash and stop using Mend's default gitAuthor

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -35,4 +35,7 @@ jobs:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_ONBOARDING: "false"
           RENOVATE_REQUIRE_CONFIG: "required"
+          # The grouped "all" branch holds many upgrades; changelog/PR-body
+          # rendering for it blew the default 4GB V8 heap (exit 134 OOM).
+          NODE_OPTIONS: "--max-old-space-size=8192"
           LOG_LEVEL: ${{ github.event.inputs.logLevel || 'info' }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "gitAuthor": "Renovate Bot <22881669+maxlerebourg@users.noreply.github.com>",
+  "fetchChangeLogs": "off",
   "labels": ["dependencies"],
   "ignorePaths": ["**/vendor/**", "**/node_modules/**"],
   "rangeStrategy": "bump",


### PR DESCRIPTION
Fixes #346

Two config fixes for the self-hosted Renovate runs:

### `renovate.json`
- **`fetchChangeLogs: "off"`** — with everything grouped into one `renovate/all` branch, Renovate fetched/held the changelog of every upgrade instance separately (Traefik `v3.0.0 -> v3.7.6` ~10x, once per compose file), blowing the default 4 GB heap (`FATAL ERROR: ... JavaScript heap out of memory`, exit 134) and crashing *between* branch push and PR creation. Release notes were mostly truncated in the grouped PR body anyway; dropping them also cuts ~20 min off each run.
- **`gitAuthor`** set to the token owner's noreply address (`22881669+maxlerebourg@users.noreply.github.com`) — silences the recurring WARN and stops commits being authored as Mend's Vigilant-Mode account, which renders every Renovate commit as red **Unverified**.

### `.github/workflows/renovate.yml`
- **`NODE_OPTIONS: --max-old-space-size=8192`** as a safety net (the action's default `env-regex` passes `NODE_OPTIONS` into the container). This also leaves the door open to re-enabling `fetchChangeLogs` later if release notes are missed.

### Not in this PR
- The `workflow` token-scope rejection from run 28648364673 is already resolved on the PAT side (a later push containing `.github/workflows/renovate.yml` succeeded).
- The orphaned `renovate/all` branch (pushed at 08:41 before the OOM, no PR opened) will be picked up by the next run — trigger the workflow manually after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)