### PR TITLE
Do not consider body unreadable when it's http.NoBody

### DIFF
--- a/bouncer.go
+++ b/bouncer.go
@@ -752,7 +752,6 @@ func appsecQuery(bouncer *Bouncer, ip string, httpReq *http.Request) error {
 		Path:   bouncer.appsecPath,
 	}
 	var req *http.Request
-	bouncer.log.Info("coucou %d", httpReq.ProtoMajor)
 	switch {
 	case isBodyUnreadable(httpReq):
 		if bouncer.appsecUnreadableBodyBlock && isMethodWithBody(httpReq.Method) {

--- a/bouncer.go
+++ b/bouncer.go
@@ -735,11 +735,7 @@ func isBodyUnreadable(httpReq *http.Request) bool {
 	return httpReq.Body != nil && httpReq.Body != http.NoBody && httpReq.ProtoMajor >= 2 && httpReq.ContentLength < 0
 }
 
-// isMethodWithBody reports whether the method is expected to carry a request
-// body. Only those methods may be dropped when their body is unreadable,
-// mirroring the reference lua-cs-bouncer METHODS_WITH_BODY list. Other methods
-// (e.g. a browser GET over HTTP/3, which never carries a Content-Length) are
-// forwarded to the Appsec component headers-only instead of dropped (issue #351).
+// isMethodWithBody used only when isBodyUnreadable returns true but the request method can't have body.
 func isMethodWithBody(method string) bool {
 	switch method {
 	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
@@ -756,10 +752,10 @@ func appsecQuery(bouncer *Bouncer, ip string, httpReq *http.Request) error {
 		Path:   bouncer.appsecPath,
 	}
 	var req *http.Request
+	bouncer.log.Info("coucou %d", httpReq.ProtoMajor)
 	switch {
 	case isBodyUnreadable(httpReq):
 		if bouncer.appsecUnreadableBodyBlock && isMethodWithBody(httpReq.Method) {
-			// The caller (handleNextServeHTTP) logs this returned error with the IP.
 			return errors.New("appsecQuery:unreadableBody dropped")
 		}
 		req, _ = http.NewRequest(http.MethodGet, routeURL.String(), nil)

--- a/bouncer.go
+++ b/bouncer.go
@@ -732,7 +732,7 @@ func crowdsecQuery(bouncer *Bouncer, stringURL string, data []byte) ([]byte, err
 // a 403. This mirrors the reference lua-cs-bouncer behavior, which refuses to
 // read the body of an HTTP/2+ request that has no Content-Length.
 func isBodyUnreadable(httpReq *http.Request) bool {
-	return httpReq.Body != nil && httpReq.ProtoMajor >= 2 && httpReq.ContentLength < 0
+	return httpReq.Body != nil && httpReq.Body != http.NoBody && httpReq.ProtoMajor >= 2 && httpReq.ContentLength < 0
 }
 
 func appsecQuery(bouncer *Bouncer, ip string, httpReq *http.Request) error {

--- a/bouncer.go
+++ b/bouncer.go
@@ -735,6 +735,20 @@ func isBodyUnreadable(httpReq *http.Request) bool {
 	return httpReq.Body != nil && httpReq.Body != http.NoBody && httpReq.ProtoMajor >= 2 && httpReq.ContentLength < 0
 }
 
+// isMethodWithBody reports whether the method is expected to carry a request
+// body. Only those methods may be dropped when their body is unreadable,
+// mirroring the reference lua-cs-bouncer METHODS_WITH_BODY list. Other methods
+// (e.g. a browser GET over HTTP/3, which never carries a Content-Length) are
+// forwarded to the Appsec component headers-only instead of dropped (issue #351).
+func isMethodWithBody(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
 func appsecQuery(bouncer *Bouncer, ip string, httpReq *http.Request) error {
 	routeURL := url.URL{
 		Scheme: bouncer.appsecScheme,
@@ -744,7 +758,7 @@ func appsecQuery(bouncer *Bouncer, ip string, httpReq *http.Request) error {
 	var req *http.Request
 	switch {
 	case isBodyUnreadable(httpReq):
-		if bouncer.appsecUnreadableBodyBlock {
+		if bouncer.appsecUnreadableBodyBlock && isMethodWithBody(httpReq.Method) {
 			// The caller (handleNextServeHTTP) logs this returned error with the IP.
 			return errors.New("appsecQuery:unreadableBody dropped")
 		}

--- a/bouncer_test.go
+++ b/bouncer_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 	"text/template"
 	"time"
@@ -396,29 +397,27 @@ func (b blockingBody) Read(_ []byte) (int, error) {
 func (blockingBody) Close() error { return nil }
 
 func Test_isBodyUnreadable(t *testing.T) {
+	realBody := func() io.ReadCloser { return io.NopCloser(strings.NewReader("data")) }
 	tests := []struct {
 		name          string
 		protoMajor    int
 		contentLength int64
-		hasBody       bool
+		body          io.ReadCloser
 		want          bool
 	}{
-		{name: "http2 grpc stream without content-length", protoMajor: 2, contentLength: -1, hasBody: true, want: true},
-		{name: "http3 stream without content-length", protoMajor: 3, contentLength: -1, hasBody: true, want: true},
-		{name: "http2 with content-length", protoMajor: 2, contentLength: 42, hasBody: true, want: false},
-		{name: "http1.1 chunked without content-length", protoMajor: 1, contentLength: -1, hasBody: true, want: false},
-		{name: "http2 without body", protoMajor: 2, contentLength: -1, hasBody: false, want: false},
+		{name: "http2 grpc stream without content-length", protoMajor: 2, contentLength: -1, body: realBody(), want: true},
+		{name: "http3 stream without content-length", protoMajor: 3, contentLength: -1, body: realBody(), want: true},
+		{name: "http2 with content-length", protoMajor: 2, contentLength: 42, body: realBody(), want: false},
+		{name: "http1.1 chunked without content-length", protoMajor: 1, contentLength: -1, body: realBody(), want: false},
+		{name: "http2 without body", protoMajor: 2, contentLength: -1, body: nil, want: false},
+		{name: "http2 with http.NoBody", protoMajor: 2, contentLength: -1, body: http.NoBody, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodPost, "http://localhost", nil)
 			req.ProtoMajor = tt.protoMajor
 			req.ContentLength = tt.contentLength
-			if tt.hasBody {
-				req.Body = http.NoBody
-			} else {
-				req.Body = nil
-			}
+			req.Body = tt.body
 			if got := isBodyUnreadable(req); got != tt.want {
 				t.Errorf("isBodyUnreadable() = %v, want %v", got, tt.want)
 			}
@@ -511,5 +510,57 @@ func Test_appsecQuery_dropUnreadableBody(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("appsecQuery() blocked on a streaming request body (issue #323 regression)")
+	}
+}
+
+// newUnreadableGetRequest builds an HTTP/3-style GET request without a
+// Content-Length, as received through Traefik's HTTP/3 entrypoint: quic-go
+// always wraps the stream in a non-nil body and sets ContentLength to -1 when
+// the header is absent, even for requests that carry no body.
+func newUnreadableGetRequest(done <-chan struct{}) *http.Request {
+	req, _ := http.NewRequest(http.MethodGet, "http://localhost/", blockingBody{done: done})
+	req.ProtoMajor = 3
+	req.ContentLength = -1
+	return req
+}
+
+// Test_appsecQuery_unreadableBodyGetNotDropped is a regression test for issue
+// #351: methods that do not carry a body (e.g. browser GETs over HTTP/3, which
+// never have a Content-Length) must be forwarded to appsec headers-only rather
+// than dropped, even with appsecUnreadableBodyBlock enabled. This mirrors the
+// reference lua-cs-bouncer METHODS_WITH_BODY behavior and its regression test
+// t/19_appsec_drop_unreadable_body_get.t.
+func Test_appsecQuery_unreadableBodyGetNotDropped(t *testing.T) {
+	appsecServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer appsecServer.Close()
+
+	appsecURL, _ := url.Parse(appsecServer.URL)
+	bouncer := &Bouncer{
+		appsecScheme:              appsecURL.Scheme,
+		appsecHost:                appsecURL.Host,
+		appsecPath:                "/",
+		appsecBodyLimit:           10485760,
+		appsecUnreadableBodyBlock: true,
+		httpAppsecClient:          appsecServer.Client(),
+		log:                       logger.New("INFO", ""),
+	}
+
+	done := make(chan struct{})
+	defer close(done)
+
+	finished := make(chan error, 1)
+	go func() {
+		finished <- appsecQuery(bouncer, "1.2.3.4", newUnreadableGetRequest(done))
+	}()
+
+	select {
+	case err := <-finished:
+		if err != nil {
+			t.Errorf("appsecQuery() on an HTTP/3 GET without content-length returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("appsecQuery() blocked on an HTTP/3 GET request body (issue #351 regression)")
 	}
 }

--- a/bouncer_test.go
+++ b/bouncer_test.go
@@ -513,10 +513,6 @@ func Test_appsecQuery_dropUnreadableBody(t *testing.T) {
 	}
 }
 
-// newUnreadableGetRequest builds an HTTP/3-style GET request without a
-// Content-Length, as received through Traefik's HTTP/3 entrypoint: quic-go
-// always wraps the stream in a non-nil body and sets ContentLength to -1 when
-// the header is absent, even for requests that carry no body.
 func newUnreadableGetRequest(done <-chan struct{}) *http.Request {
 	req, _ := http.NewRequest(http.MethodGet, "http://localhost/", blockingBody{done: done})
 	req.ProtoMajor = 3
@@ -524,12 +520,7 @@ func newUnreadableGetRequest(done <-chan struct{}) *http.Request {
 	return req
 }
 
-// Test_appsecQuery_unreadableBodyGetNotDropped is a regression test for issue
-// #351: methods that do not carry a body (e.g. browser GETs over HTTP/3, which
-// never have a Content-Length) must be forwarded to appsec headers-only rather
-// than dropped, even with appsecUnreadableBodyBlock enabled. This mirrors the
-// reference lua-cs-bouncer METHODS_WITH_BODY behavior and its regression test
-// t/19_appsec_drop_unreadable_body_get.t.
+// Test_appsecQuery_unreadableBodyGetNotDropped is a regression test for issue #351
 func Test_appsecQuery_unreadableBodyGetNotDropped(t *testing.T) {
 	appsecServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.WriteHeader(http.StatusOK)

--- a/tests/e2e/mock/scenarios/appsec/dynamic.yml
+++ b/tests/e2e/mock/scenarios/appsec/dynamic.yml
@@ -18,7 +18,7 @@ http:
         bouncer:
           enabled: "true"
           # IP bouncing disabled — this scenario exercises AppSec only.
-          crowdsecMode: none
+          crowdsecMode: appsec
           crowdsecLapiScheme: http
           crowdsecLapiHost: "@@LAPI_HOST@@"
           crowdsecLapiKey: "@@APIKEY@@"

--- a/tests/e2e/mock/scenarios/appsec/run.sh
+++ b/tests/e2e/mock/scenarios/appsec/run.sh
@@ -31,10 +31,13 @@ body() {
   echo "[$SCENARIO] request that send bad body before crowdsecAppsecBodyLimit must pass (AppSec 403)"
   assert_status "http://127.0.0.1:${WEB_PORT}/foo" 403 -H "X-Forwarded-For: 1.2.3.4" -X POST -d "a=0&______"
 
-  echo "[$SCENARIO] request that send unreadable body GET (AppSec 200)"
+  echo "[$SCENARIO] request http2 that send no body GET (AppSec 200)"
   assert_status "http://127.0.0.1:${WEB_PORT}/foo" 200 -H "X-Forwarded-For: 1.2.3.4" --http2-prior-knowledge -H "Content-Length:"
 
-  echo "[$SCENARIO] request that send unreadable body POST (AppSec 403)"
+  echo "[$SCENARIO] request http2 that send unreadable body GET (AppSec 403)"
+  assert_status "http://127.0.0.1:${WEB_PORT}/foo" 200 -H "X-Forwarded-For: 1.2.3.4" --http2-prior-knowledge -H "Content-Length:" -d "test"
+
+  echo "[$SCENARIO] request http2 that send unreadable body POST (AppSec 403)"
   assert_status "http://127.0.0.1:${WEB_PORT}/foo" 403 -H "X-Forwarded-For: 1.2.3.4" --http2-prior-knowledge -H "Content-Length:" -X POST -d "test"
 }
 

--- a/tests/e2e/mock/scenarios/appsec/run.sh
+++ b/tests/e2e/mock/scenarios/appsec/run.sh
@@ -30,6 +30,12 @@ body() {
 
   echo "[$SCENARIO] request that send bad body before crowdsecAppsecBodyLimit must pass (AppSec 403)"
   assert_status "http://127.0.0.1:${WEB_PORT}/foo" 403 -H "X-Forwarded-For: 1.2.3.4" -X POST -d "a=0&______"
+
+  echo "[$SCENARIO] request that send unreadable body GET (AppSec 200)"
+  assert_status "http://127.0.0.1:${WEB_PORT}/foo" 200 -H "X-Forwarded-For: 1.2.3.4" --http2-prior-knowledge -H "Content-Length:"
+
+  echo "[$SCENARIO] request that send unreadable body POST (AppSec 403)"
+  assert_status "http://127.0.0.1:${WEB_PORT}/foo" 403 -H "X-Forwarded-For: 1.2.3.4" --http2-prior-knowledge -H "Content-Length:" -X POST -d "test"
 }
 
 run_scenario "$SCENARIO" "$HERE" body

--- a/tests/e2e/mock/scenarios/appsec/run.sh
+++ b/tests/e2e/mock/scenarios/appsec/run.sh
@@ -35,7 +35,7 @@ body() {
   assert_status "http://127.0.0.1:${WEB_PORT}/foo" 200 -H "X-Forwarded-For: 1.2.3.4" --http2-prior-knowledge -H "Content-Length:"
 
   echo "[$SCENARIO] request http2 that send unreadable body GET (AppSec 403)"
-  assert_status "http://127.0.0.1:${WEB_PORT}/foo" 200 -H "X-Forwarded-For: 1.2.3.4" --http2-prior-knowledge -H "Content-Length:" -d "test"
+  assert_status "http://127.0.0.1:${WEB_PORT}/foo" 403 -H "X-Forwarded-For: 1.2.3.4" --http2-prior-knowledge -H "Content-Length:" -d "test"
 
   echo "[$SCENARIO] request http2 that send unreadable body POST (AppSec 403)"
   assert_status "http://127.0.0.1:${WEB_PORT}/foo" 403 -H "X-Forwarded-For: 1.2.3.4" --http2-prior-knowledge -H "Content-Length:" -X POST -d "test"


### PR DESCRIPTION
GET requests (or any req which has no body) do not have a nil httpReq.Body on the server side. Instead, its value is http.NoBody. Check for Body == http.NoBody in isBodyUnreadable to prevent blocking every GET request

Fix #351