### PR TITLE
✨ feat: serve captcha for bans from configured decision origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,10 @@ make run
   - string
   - default: /captcha.html
   - Path where the captcha template is stored. The Content-Type header is automatically inferred from the file extension.
+- CaptchaBanOrigins
+  - []string
+  - default: [] (disabled)
+  - Decision origins whose `ban` decisions are served the captcha remediation instead. Useful for decisions whose type cannot be chosen at the source, such as the CAPI community blocklist and console-subscribed blocklists (origins `CAPI` and `lists`), which always arrive as `ban`. Local scenario decisions keep the type set by your `profiles.yaml`, and origins that are not listed are unaffected — e.g. `["CAPI", "lists"]` still bans everything you or your scenarios decided to ban. Requires a captcha provider to be configured; without one the captcha remediation falls back to the ban page.
 - BanFilePath
   - string
   - default: ""

--- a/bouncer.go
+++ b/bouncer.go
@@ -118,6 +118,7 @@ type Bouncer struct {
 	httpClient                *http.Client
 	httpAppsecClient          *http.Client
 	cacheClient               *cache.Client
+	captchaBanOrigins         []string
 	captchaClient             *captcha.Client
 	log                       *slog.Logger
 }
@@ -257,8 +258,9 @@ func New(_ context.Context, next http.Handler, config *configuration.Config, nam
 			},
 			Timeout: time.Duration(config.HTTPTimeoutSeconds) * time.Second,
 		},
-		cacheClient:   &cache.Client{},
-		captchaClient: &captcha.Client{},
+		cacheClient:       &cache.Client{},
+		captchaBanOrigins: config.CaptchaBanOrigins,
+		captchaClient:     &captcha.Client{},
 	}
 	if config.CrowdsecMode == configuration.AppsecMode {
 		return bouncer, nil
@@ -568,7 +570,7 @@ func handleNoStreamCache(bouncer *Bouncer, remoteIP string) (string, error) {
 	var decision Decision
 	for _, d := range decisions {
 		decision = d
-		if decision.Type == "ban" {
+		if bouncer.remediationForDecision(decision) == cache.BannedValue {
 			break
 		}
 	}
@@ -576,15 +578,7 @@ func handleNoStreamCache(bouncer *Bouncer, remoteIP string) (string, error) {
 	if err != nil {
 		return cache.BannedValue, fmt.Errorf("handleNoStreamCache:parseDuration %w", err)
 	}
-	var value string
-	switch decision.Type {
-	case "ban":
-		value = cache.BannedValue
-	case "captcha":
-		value = cache.CaptchaValue
-	default:
-		bouncer.log.Info("handleStreamCache:unknownType " + decision.Type)
-	}
+	value := bouncer.remediationForDecision(decision)
 	if isLiveMode && bouncer.defaultDecisionTimeout > 0 {
 		durationSecond := int64(duration.Seconds())
 		if bouncer.defaultDecisionTimeout < durationSecond {
@@ -593,6 +587,30 @@ func handleNoStreamCache(bouncer *Bouncer, remoteIP string) (string, error) {
 		bouncer.cacheClient.Set(remoteIP, value, durationSecond)
 	}
 	return value, errors.New("handleNoStreamCache:banned")
+}
+
+// remediationForDecision returns the cache value to store for a decision.
+//
+// A ban whose origin is listed in CaptchaBanOrigins is stored as a captcha
+// remediation instead. This makes remediation configurable for decisions whose
+// type cannot be changed at the source — most notably the CAPI community
+// blocklist and console-subscribed lists, which always arrive as "ban".
+// When CaptchaBanOrigins is empty (the default) the mapping is a no-op.
+func (bouncer *Bouncer) remediationForDecision(decision Decision) string {
+	switch decision.Type {
+	case "ban":
+		for _, origin := range bouncer.captchaBanOrigins {
+			if origin == decision.Origin {
+				bouncer.log.Debug("remediationForDecision:banToCaptcha origin:" + decision.Origin)
+				return cache.CaptchaValue
+			}
+		}
+		return cache.BannedValue
+	case "captcha":
+		return cache.CaptchaValue
+	}
+	bouncer.log.Info("remediationForDecision:unknownType " + decision.Type)
+	return ""
 }
 
 func getToken(bouncer *Bouncer) error {
@@ -660,16 +678,7 @@ func handleStreamCache(bouncer *Bouncer) error {
 	for _, decision := range stream.New {
 		duration, err := time.ParseDuration(decision.Duration)
 		if err == nil {
-			var value string
-			switch decision.Type {
-			case "ban":
-				value = cache.BannedValue
-			case "captcha":
-				value = cache.CaptchaValue
-			default:
-				bouncer.log.Info("handleStreamCache:unknownType " + decision.Type)
-			}
-			bouncer.cacheClient.Set(decision.Value, value, int64(duration.Seconds()))
+			bouncer.cacheClient.Set(decision.Value, bouncer.remediationForDecision(decision), int64(duration.Seconds()))
 		}
 	}
 	for _, decision := range stream.Deleted {

--- a/bouncer_captcha_ban_origins_test.go
+++ b/bouncer_captcha_ban_origins_test.go
@@ -1,0 +1,72 @@
+package crowdsec_bouncer_traefik_plugin //nolint:revive,stylecheck
+
+import (
+	"testing"
+
+	cache "github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/pkg/cache"
+	logger "github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/pkg/logger"
+)
+
+func TestRemediationForDecision(t *testing.T) {
+	log := logger.New("INFO", "")
+	configured := &Bouncer{log: log, captchaBanOrigins: []string{"CAPI", "lists"}}
+	defaultCfg := &Bouncer{log: log, captchaBanOrigins: []string{}}
+
+	tests := []struct {
+		name     string
+		bouncer  *Bouncer
+		decision Decision
+		expected string
+	}{
+		{
+			name:     "ban from a listed origin is served a captcha",
+			bouncer:  configured,
+			decision: Decision{Type: "ban", Origin: "CAPI"},
+			expected: cache.CaptchaValue,
+		},
+		{
+			name:     "ban from another listed origin is served a captcha",
+			bouncer:  configured,
+			decision: Decision{Type: "ban", Origin: "lists"},
+			expected: cache.CaptchaValue,
+		},
+		{
+			name:     "ban from an unlisted origin stays a ban",
+			bouncer:  configured,
+			decision: Decision{Type: "ban", Origin: "crowdsec"},
+			expected: cache.BannedValue,
+		},
+		{
+			name:     "manual cscli ban stays a ban",
+			bouncer:  configured,
+			decision: Decision{Type: "ban", Origin: "cscli"},
+			expected: cache.BannedValue,
+		},
+		{
+			name:     "captcha decision is unaffected",
+			bouncer:  configured,
+			decision: Decision{Type: "captcha", Origin: "crowdsec"},
+			expected: cache.CaptchaValue,
+		},
+		{
+			name:     "default configuration maps nothing",
+			bouncer:  defaultCfg,
+			decision: Decision{Type: "ban", Origin: "CAPI"},
+			expected: cache.BannedValue,
+		},
+		{
+			name:     "unknown decision type keeps the previous behaviour",
+			bouncer:  configured,
+			decision: Decision{Type: "mfa", Origin: "CAPI"},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.bouncer.remediationForDecision(tt.decision); got != tt.expected {
+				t.Errorf("remediationForDecision() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -115,6 +115,7 @@ type Config struct {
 	CaptchaSecretKey                           string   `json:"captchaSecretKey,omitempty"`
 	CaptchaSecretKeyFile                       string   `json:"captchaSecretKeyFile,omitempty"`
 	CaptchaGracePeriodSeconds                  int64    `json:"captchaGracePeriodSeconds,omitempty"`
+	CaptchaBanOrigins                          []string `json:"captchaBanOrigins,omitempty"`
 }
 
 func contains(source []string, target string) bool {
@@ -164,6 +165,7 @@ func New() *Config {
 		CaptchaSiteKey:                    "",
 		CaptchaSecretKey:                  "",
 		CaptchaGracePeriodSeconds:         1800,
+		CaptchaBanOrigins:                 []string{},
 		CaptchaFilePath:                   "/captcha.html",
 		BanFilePath:                       "",
 		TraceHeadersCustomName:            "",

--- a/tests/e2e/mock/lib/common.sh
+++ b/tests/e2e/mock/lib/common.sh
@@ -157,8 +157,8 @@ assert_body_contains() {
 # --- mock admin client -------------------------------------------------------
 
 lapi_add_decision() {
-  local ip="$1" type="${2:-ban}" duration="${3:-4h}"
-  curl -sS -X POST "http://127.0.0.1:${LAPI_PORT}/admin/decisions?ip=${ip}&type=${type}&duration=${duration}" >/dev/null
+  local ip="$1" type="${2:-ban}" duration="${3:-4h}" origin="${4:-crowdsec}"
+  curl -sS -X POST "http://127.0.0.1:${LAPI_PORT}/admin/decisions?ip=${ip}&type=${type}&duration=${duration}&origin=${origin}" >/dev/null
 }
 
 lapi_delete_decision() {

--- a/tests/e2e/mock/mocklapi/main.go
+++ b/tests/e2e/mock/mocklapi/main.go
@@ -28,6 +28,7 @@ type Decision struct {
 	Value    string `json:"value"`
 	Type     string `json:"type"`
 	Duration string `json:"duration"`
+	Origin   string `json:"origin"`
 }
 
 var (
@@ -199,7 +200,11 @@ func main() {
 			if duration == "" {
 				duration = "4h"
 			}
-			active[ip] = Decision{Value: ip, Type: dtype, Duration: duration}
+			origin := q.Get("origin")
+			if origin == "" {
+				origin = "crowdsec"
+			}
+			active[ip] = Decision{Value: ip, Type: dtype, Duration: duration, Origin: origin}
 			delete(deleted, ip)
 		case http.MethodDelete:
 			if d, ok := active[ip]; ok {

--- a/tests/e2e/mock/scenarios/captcha-ban-origins/captcha.html
+++ b/tests/e2e/mock/scenarios/captcha-ban-origins/captcha.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>E2E captcha marker</title></head>
+<body>
+<h1 id="e2e-captcha-marker">E2E_CAPTCHA_PAGE_MARKER</h1>
+<script src="{{ .FrontendJS }}"></script>
+<div class="{{ .FrontendKey }}" data-sitekey="{{ .SiteKey }}"></div>
+</body>
+</html>

--- a/tests/e2e/mock/scenarios/captcha-ban-origins/dynamic.yml
+++ b/tests/e2e/mock/scenarios/captcha-ban-origins/dynamic.yml
@@ -1,0 +1,39 @@
+http:
+  routers:
+    r:
+      rule: "PathPrefix(`/foo`)"
+      entryPoints:
+        - web
+      service: backend
+      middlewares:
+        - bouncer
+  services:
+    backend:
+      loadBalancer:
+        servers:
+          - url: "@@BACKEND_URL@@"
+  middlewares:
+    bouncer:
+      plugin:
+        bouncer:
+          enabled: "true"
+          crowdsecMode: stream
+          updateIntervalSeconds: "2"
+          crowdsecLapiScheme: http
+          crowdsecLapiHost: "@@LAPI_HOST@@"
+          crowdsecLapiKey: "@@APIKEY@@"
+          forwardedHeadersTrustedIps:
+            - "127.0.0.1/32"
+          captchaProvider: turnstile
+          # Cloudflare Turnstile public test keys: render a valid widget without
+          # contacting a real API key.
+          captchaSiteKey: "1x00000000000000000000AA"
+          captchaSecretKey: "1x0000000000000000000000000000000AA"
+          captchaHtmlFilePath: "@@SCENARIO_DIR@@/captcha.html"
+          captchaGracePeriodSeconds: "10"
+          # Bans coming from these origins are served the captcha instead. The
+          # community blocklist ("CAPI") and console blocklists ("lists") always
+          # arrive as type "ban" and cannot be retyped at the source.
+          captchaBanOrigins:
+            - "CAPI"
+            - "lists"

--- a/tests/e2e/mock/scenarios/captcha-ban-origins/run.sh
+++ b/tests/e2e/mock/scenarios/captcha-ban-origins/run.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../../lib/common.sh
+source "$HERE/../../lib/common.sh"
+
+SCENARIO=captcha-ban-origins
+
+# captchaBanOrigins: ["CAPI", "lists"] — a *ban* from those origins must be
+# served the captcha remediation, while bans from any other origin stay bans.
+body() {
+  echo "[$SCENARIO] ban from a listed origin (CAPI) must render the captcha page"
+  lapi_add_decision 1.2.3.4 ban 5m CAPI
+  wait_for_body_contains "http://127.0.0.1:${WEB_PORT}/foo" "E2E_CAPTCHA_PAGE_MARKER" 15 -H "X-Forwarded-For: 1.2.3.4"
+
+  echo "[$SCENARIO] ... and it is HTTP 200 (the captcha page), not the 403 ban page"
+  assert_status "http://127.0.0.1:${WEB_PORT}/foo" 200 -H "X-Forwarded-For: 1.2.3.4"
+
+  echo "[$SCENARIO] ban from the other listed origin (lists) also renders the captcha page"
+  lapi_add_decision 1.2.3.5 ban 5m lists
+  wait_for_body_contains "http://127.0.0.1:${WEB_PORT}/foo" "E2E_CAPTCHA_PAGE_MARKER" 15 -H "X-Forwarded-For: 1.2.3.5"
+
+  echo "[$SCENARIO] ban from an UNLISTED origin (cscli) must stay a 403 ban"
+  lapi_add_decision 1.2.3.6 ban 5m cscli
+  wait_for_status "http://127.0.0.1:${WEB_PORT}/foo" 403 15 -H "X-Forwarded-For: 1.2.3.6"
+
+  echo "[$SCENARIO] ban from a local scenario (crowdsec) must stay a 403 ban"
+  lapi_add_decision 1.2.3.7 ban 5m crowdsec
+  wait_for_status "http://127.0.0.1:${WEB_PORT}/foo" 403 15 -H "X-Forwarded-For: 1.2.3.7"
+
+  echo "[$SCENARIO] a captcha decision is unaffected by the mapping"
+  lapi_add_decision 1.2.3.8 captcha 5m crowdsec
+  wait_for_body_contains "http://127.0.0.1:${WEB_PORT}/foo" "E2E_CAPTCHA_PAGE_MARKER" 15 -H "X-Forwarded-For: 1.2.3.8"
+
+  echo "[$SCENARIO] an IP with no decision still passes through to the backend"
+  assert_status "http://127.0.0.1:${WEB_PORT}/foo" 200 -H "X-Forwarded-For: 5.6.7.8"
+}
+
+run_scenario "$SCENARIO" "$HERE" body


### PR DESCRIPTION
## Problem

The CAPI community blocklist (and console-subscribed blocklists) always deliver decisions of type `ban`, and that type cannot be changed anywhere:

- **CrowdSec console** — per-subscription remediation is offered for *catalog* blocklists; the Community Blocklist's menu has no such setting.
- **`profiles.yaml`** — only shapes locally generated alerts; CAPI decisions arrive pre-typed and never pass through it.
- **This plugin** — maps purely on `decision.Type`.

On a typical setup that is the overwhelming majority of decisions. On mine it is 26 093 of 26 122 decisions in a single stream response:

```
origins in stream: {'CAPI': 26093, 'crowdsec': 28, 'cscli': 1}
```

So a site can already offer a captcha for its own scenario decisions, but a legitimate visitor whose address sits on a shared community blocklist gets a hard 403 with no way through. That is exactly the case that motivated this: a real user reported "403 on every page" — their VPN hands out addresses from a /24 where 119 of 256 are CAPI-banned for `http:scan`. Nothing they or I could configure would let them prove they were human.

## Change

`CaptchaBanOrigins []string` — a `ban` decision whose `origin` is listed is stored with the captcha remediation instead.

`Decision.Origin` was already parsed and unused, so the diff is small: one option, one helper (`remediationForDecision`), used by the three places that mapped a decision to a cache value. The live-mode "prefer a ban" selection loop now prefers a decision that still maps to a ban.

- **Empty by default → complete no-op**, behaviour is unchanged for everyone who does not set it.
- **Unlisted origins are untouched** — `["CAPI", "lists"]` still bans everything your scenarios and your `cscli` bans decided to ban.
- Without a captcha provider configured, a captcha value already falls back to ban rendering, so the option cannot accidentally open anything up.

```yaml
captchaProvider: turnstile
captchaSiteKeyFile: /etc/traefik/turnstile_site_key
captchaSecretKeyFile: /etc/traefik/turnstile_secret_key
captchaBanOrigins: ["CAPI", "lists"]
```

## Testing

- Table test for the mapping (`bouncer_captcha_ban_origins_test.go`), `go vet` and the full suite pass, `gofmt` clean.
- Verified end to end in production against a **genuine CAPI decision**, not a stand-in: a throwaway docker network whose subnet is the banned range let a container hold `185.220.101.100` (a real `http:scan` community ban). From that source address the configured vhost served the Turnstile page and solving it let the request through, while another vhost on the same instance — same decision, option unset — served the ban page.

## Related

- #312 asks for origin-aware decision handling for a different purpose (filtering which decisions a bouncer applies). Same axis, different goal; happy to reshape this into a more general `remediationByOrigin` mapping if you would rather have one mechanism cover both.

## One caveat worth flagging

When Traefik re-instantiates a middleware after a dynamic-config change, the previous instance's decision-stream ticker is not stopped, and every ticker writes the package-level cache. An old goroutine therefore keeps overwriting the new mapping with its previous origin list, so changing this option needs a Traefik **restart** rather than a reload. That is pre-existing behaviour rather than something this PR introduces, but it is very visible with a config option like this one — happy to look at it separately if you consider it in scope.