### PR TITLE
:bug: keep the stream lease alive when updateIntervalSeconds is 1

### DIFF
--- a/bouncer.go
+++ b/bouncer.go
@@ -641,7 +641,13 @@ func handleStreamCache(bouncer *Bouncer) error {
 	if err.Error() != cache.CacheMiss {
 		return err
 	}
-	bouncer.cacheClient.Set(cacheTimeoutKey, cache.NoBannedValue, bouncer.updateInterval-1)
+	// The lease expires just before the next tick, but it also has to be stored at all:
+	// the local cache ignores a zero duration and redis rejects a non positive EX.
+	leaseDuration := bouncer.updateInterval - 1
+	if leaseDuration < 1 {
+		leaseDuration = 1
+	}
+	bouncer.cacheClient.Set(cacheTimeoutKey, cache.NoBannedValue, leaseDuration)
 	streamRouteURL := url.URL{
 		Scheme:   bouncer.crowdsecScheme,
 		Host:     bouncer.crowdsecHost,

--- a/bouncer.go
+++ b/bouncer.go
@@ -641,8 +641,7 @@ func handleStreamCache(bouncer *Bouncer) error {
 	if err.Error() != cache.CacheMiss {
 		return err
 	}
-	// The lease expires just before the next tick, but it also has to be stored at all:
-	// the local cache ignores a zero duration and redis rejects a non positive EX.
+	// To avoid every instance trying to update the cache, set 1 second at least
 	leaseDuration := bouncer.updateInterval - 1
 	if leaseDuration < 1 {
 		leaseDuration = 1


### PR DESCRIPTION
Fixes #370.

`handleStreamCache` takes a lease so a single node polls LAPI per interval, and stores it for `updateInterval - 1` seconds. At `updateIntervalSeconds: 1` — a supported value, validated as `>= 1` in `pkg/configuration` — that duration is `0`, and neither backend stores a key with a zero TTL:

- `golang-ttl-map` returns early before storing (`map.go:113`)
- simpleredis sends `SET … EX 0`, which redis rejects

So the lease is never stored, the next `Get` misses, and every node polls LAPI on every tick instead of one of them.

### Change

Floor the lease duration at 1 second.

At an interval of 1 the lease can then survive a tick that fires slightly early, costing one skipped poll. That is the right trade: a skipped poll delays a decision by one second, while the current behaviour multiplies LAPI load by the number of bouncers.

### Notes

- Independent of #368 — the bug is on `main` today, this branch is based on `main`.
- Silent on the local cache and only a log line on redis, so it does not surface in single-node testing. Not covered by the mock e2e suite, which runs one bouncer: reproducing it needs several instances against a shared redis.
- `redisCache.set` logs the failure but callers cannot tell "stored" from "not stored". Left alone here, noted in #370.

### Checks

`go build`, `go vet`, `gofmt`, `go test ./pkg/...`, and `make e2e_mock` (9/9 scenarios) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
