### PR TITLE
Disable request blocking when CrowdSec is unavailable in live mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,8 @@ make run
 - UpdateMaxFailure
   - int64
   - default: 0
-  - Used only in `stream` and `alone` mode, the maximum number of time we can not reach Crowdsec before blocking traffic (set -1 to never block)
+  - In `stream` and `alone` mode, the maximum number of time we can not reach Crowdsec before blocking traffic (set -1 to never block)
+  - In `live` and `none` mode, only `-1` has an effect: a request is let through instead of blocked when Crowdsec cannot be reached. Any other value blocks on the first failure, there is no failure counter on that path.
 - StreamStartupBlock
   - bool
   - default: true

--- a/bouncer.go
+++ b/bouncer.go
@@ -544,6 +544,9 @@ func handleNoStreamCache(bouncer *Bouncer, remoteIP string) (string, error) {
 	}
 	body, err := crowdsecQuery(bouncer, routeURL.String(), nil)
 	if err != nil {
+		if bouncer.updateMaxFailure == -1 {
+			return cache.NoBannedValue, err
+		}
 		return cache.BannedValue, err
 	}
 

--- a/bouncer_test.go
+++ b/bouncer_test.go
@@ -122,21 +122,67 @@ func TestBouncer_ServeHTTP(t *testing.T) {
 }
 
 func Test_handleNoStreamCache(t *testing.T) {
-	type args struct {
-		bouncer  *Bouncer
-		remoteIP string
+	newBouncer := func(mode string, updateMaxFailure int64) *Bouncer {
+		log := logger.New("ERROR", "")
+		cacheClient := &cache.Client{}
+		cacheClient.New(log, false, "", nil, "", "")
+		return &Bouncer{
+			crowdsecScheme:         "http",
+			crowdsecHost:           "127.0.0.1:1",
+			crowdsecPath:           "/",
+			crowdsecMode:           mode,
+			updateMaxFailure:       updateMaxFailure,
+			defaultDecisionTimeout: 60,
+			httpClient:             &http.Client{Timeout: time.Second},
+			cacheClient:            cacheClient,
+			log:                    log,
+		}
 	}
+
 	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
+		name             string
+		mode             string
+		updateMaxFailure int64
+		want             string
+		wantErr          bool
 	}{
-		// TODO: Add test cases.
+		{
+			name:             "live mode blocks by default when crowdsec is unreachable",
+			mode:             configuration.LiveMode,
+			updateMaxFailure: 0,
+			want:             cache.BannedValue,
+			wantErr:          true,
+		},
+		{
+			name:             "live mode blocks for any positive updateMaxFailure",
+			mode:             configuration.LiveMode,
+			updateMaxFailure: 3,
+			want:             cache.BannedValue,
+			wantErr:          true,
+		},
+		{
+			name:             "live mode lets the request through when updateMaxFailure is -1",
+			mode:             configuration.LiveMode,
+			updateMaxFailure: -1,
+			want:             cache.NoBannedValue,
+			wantErr:          true,
+		},
+		{
+			name:             "none mode lets the request through when updateMaxFailure is -1",
+			mode:             configuration.NoneMode,
+			updateMaxFailure: -1,
+			want:             cache.NoBannedValue,
+			wantErr:          true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := handleNoStreamCache(tt.args.bouncer, tt.args.remoteIP); (err != nil) != tt.wantErr {
+			got, err := handleNoStreamCache(newBouncer(tt.mode, tt.updateMaxFailure), "1.2.3.4")
+			if (err != nil) != tt.wantErr {
 				t.Errorf("handleNoStreamCache() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("handleNoStreamCache() = %q, want %q", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Added the ability to disable request blocking if CrowdSec is unavailable in `live` mode.
Utilized the existing `UpdateMaxFailure` option, originally intended for `stream` and `alone` modes.

https://github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/issues/297


P.S. I am not very familiar with Go. These are local changes I wrote with the help of AI. Nevertheless, they have already been tested in a production environment, and I am satisfied with the result. If I haven't followed the coding guidelines for this project, I apologize in advance and please feel free to correct any errors if necessary. Thank you.

