### PR TITLE
🐛 self-heal stalled stream polling

### DIFF
--- a/bouncer.go
+++ b/bouncer.go
@@ -70,6 +70,8 @@ var (
 	metricsTicker           chan bool
 	lastMetricsPush         time.Time
 	blockedRequests         int64
+	lastStreamTickerRun     int64
+	streamUpdateInProgress  int32
 )
 
 // CreateConfig creates the default plugin configuration.
@@ -312,6 +314,9 @@ func New(_ context.Context, next http.Handler, config *configuration.Config, nam
 		streamTicker = startTicker("stream", config.UpdateIntervalSeconds, log, func() {
 			handleStreamTicker(bouncer)
 		})
+		startTicker("stream_watchdog", config.UpdateIntervalSeconds, log, func() {
+			handleStreamWatchdog(bouncer)
+		})
 	}
 
 	// Start metrics ticker if not already running
@@ -497,6 +502,13 @@ func (bouncer *Bouncer) handleNextServeHTTP(rw http.ResponseWriter, req *http.Re
 }
 
 func handleStreamTicker(bouncer *Bouncer) {
+	if !atomic.CompareAndSwapInt32(&streamUpdateInProgress, 0, 1) {
+		bouncer.log.Debug("handleStreamTicker:alreadyRunning")
+		return
+	}
+	atomic.StoreInt64(&lastStreamTickerRun, time.Now().UnixNano())
+	defer atomic.StoreInt32(&streamUpdateInProgress, 0)
+
 	if err := handleStreamCache(bouncer); err != nil {
 		bouncer.log.Warn(fmt.Sprintf("handleStreamTicker updateFailure:%d isCrowdsecStreamHealthy:%t %s", updateFailure, isCrowdsecStreamHealthy, err.Error()))
 		if bouncer.updateMaxFailure != -1 && updateFailure >= bouncer.updateMaxFailure && isCrowdsecStreamHealthy {
@@ -510,7 +522,37 @@ func handleStreamTicker(bouncer *Bouncer) {
 	}
 }
 
+func streamTickerNeedsRecovery(lastRun int64, now time.Time, updateInterval int64) bool {
+	if updateInterval < 1 {
+		return false
+	}
+	if lastRun == 0 {
+		return true
+	}
+
+	lastRunAt := time.Unix(0, lastRun)
+	return !now.Before(lastRunAt) && now.Sub(lastRunAt) >= 2*time.Duration(updateInterval)*time.Second
+}
+
+func handleStreamWatchdog(bouncer *Bouncer) {
+	if bouncer.crowdsecMode != configuration.StreamMode && bouncer.crowdsecMode != configuration.AloneMode {
+		return
+	}
+	if atomic.LoadInt32(&streamUpdateInProgress) != 0 {
+		return
+	}
+
+	lastRun := atomic.LoadInt64(&lastStreamTickerRun)
+	if !streamTickerNeedsRecovery(lastRun, time.Now(), bouncer.updateInterval) {
+		return
+	}
+
+	bouncer.log.Warn("handleStreamWatchdog: stream ticker stale, forcing a refresh")
+	handleStreamTicker(bouncer)
+}
+
 func handleMetricsTicker(bouncer *Bouncer) {
+	handleStreamWatchdog(bouncer)
 	if err := reportMetrics(bouncer); err != nil {
 		bouncer.log.Error("handleMetricsTicker:reportMetrics " + err.Error())
 	}

--- a/bouncer.go
+++ b/bouncer.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"text/template"
 	"time"
@@ -63,16 +64,36 @@ const (
 
 //nolint:gochecknoglobals
 var (
-	isCrowdsecStreamStartup = true
-	isCrowdsecStreamHealthy = true
+	isCrowdsecStreamStartup int32 = 1
+	isCrowdsecStreamHealthy int32 = 1
 	updateFailure           int64
-	streamTicker            chan bool
-	metricsTicker           chan bool
 	lastMetricsPush         time.Time
 	blockedRequests         int64
+	processStart            = time.Now()
 	lastStreamTickerRun     int64
-	streamUpdateInProgress  int32
+	tickers                 tickerRuntime
 )
+
+type tickerRuntime struct {
+	streamOnce           sync.Once
+	metricsOnce          sync.Once
+	streamTicker         chan bool
+	streamWatchdogTicker chan bool
+	metricsTicker        chan bool
+	streamInitialization error
+}
+
+func atomicBoolLoad(value *int32) bool {
+	return atomic.LoadInt32(value) != 0
+}
+
+func atomicBoolStore(value *int32, enabled bool) {
+	var raw int32
+	if enabled {
+		raw = 1
+	}
+	atomic.StoreInt32(value, raw)
+}
 
 // CreateConfig creates the default plugin configuration.
 func CreateConfig() *configuration.Config {
@@ -126,7 +147,7 @@ type Bouncer struct {
 
 // New creates the crowdsec bouncer plugin.
 //
-//nolint:nestif,gocyclo,gocognit,funlen,maintidx
+//nolint:gocyclo
 func New(_ context.Context, next http.Handler, config *configuration.Config, name string) (http.Handler, error) {
 	config.LogLevel = strings.ToUpper(config.LogLevel)
 	log := logger.NewWithFormat(config.LogLevel, config.LogFilePath, config.LogFormat)
@@ -299,33 +320,14 @@ func New(_ context.Context, next http.Handler, config *configuration.Config, nam
 		return nil, err
 	}
 
-	if (config.CrowdsecMode == configuration.StreamMode || config.CrowdsecMode == configuration.AloneMode) && streamTicker == nil {
-		if config.CrowdsecMode == configuration.AloneMode {
-			if err := getToken(bouncer); err != nil {
-				bouncer.log.Error("New:getToken " + err.Error())
-				return nil, err
-			}
+	if config.CrowdsecMode == configuration.StreamMode || config.CrowdsecMode == configuration.AloneMode {
+		if err := tickers.startStream(bouncer, config, log); err != nil {
+			return nil, err
 		}
-		if config.StreamStartupBlock {
-			handleStreamTicker(bouncer)
-		} else {
-			go handleStreamTicker(bouncer)
-		}
-		streamTicker = startTicker("stream", config.UpdateIntervalSeconds, log, func() {
-			handleStreamTicker(bouncer)
-		})
-		startTicker("stream_watchdog", config.UpdateIntervalSeconds, log, func() {
-			handleStreamWatchdog(bouncer)
-		})
 	}
 
-	// Start metrics ticker if not already running
-	if metricsTicker == nil && config.MetricsUpdateIntervalSeconds > 0 {
-		lastMetricsPush = time.Now() // Initialize lastMetricsPush when starting the metrics ticker
-		go handleMetricsTicker(bouncer)
-		metricsTicker = startTicker("metrics", config.MetricsUpdateIntervalSeconds, log, func() {
-			handleMetricsTicker(bouncer)
-		})
+	if config.MetricsUpdateIntervalSeconds > 0 {
+		tickers.startMetrics(bouncer, config, log)
 	}
 
 	bouncer.log.Debug("New initialized mode:" + config.CrowdsecMode)
@@ -396,10 +398,10 @@ func (bouncer *Bouncer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	// Right here if we cannot join the stream we forbid the request to go on.
 	if bouncer.crowdsecMode == configuration.StreamMode || bouncer.crowdsecMode == configuration.AloneMode {
-		if isCrowdsecStreamHealthy {
+		if atomicBoolLoad(&isCrowdsecStreamHealthy) {
 			bouncer.handleNextServeHTTP(rw, req, remoteIP)
 		} else {
-			bouncer.log.Debug(fmt.Sprintf("ServeHTTP isCrowdsecStreamHealthy:false ip:%s updateFailure:%d", remoteIP, updateFailure))
+			bouncer.log.Debug(fmt.Sprintf("ServeHTTP isCrowdsecStreamHealthy:false ip:%s updateFailure:%d", remoteIP, atomic.LoadInt64(&updateFailure)))
 			bouncer.handleBanServeHTTP(rw, req, remoteIP, configuration.ReasonTECH)
 		}
 	} else {
@@ -502,27 +504,27 @@ func (bouncer *Bouncer) handleNextServeHTTP(rw http.ResponseWriter, req *http.Re
 }
 
 func handleStreamTicker(bouncer *Bouncer) {
-	if !atomic.CompareAndSwapInt32(&streamUpdateInProgress, 0, 1) {
-		bouncer.log.Debug("handleStreamTicker:alreadyRunning")
-		return
-	}
-	atomic.StoreInt64(&lastStreamTickerRun, time.Now().UnixNano())
-	defer atomic.StoreInt32(&streamUpdateInProgress, 0)
+	markStreamRun()
 
 	if err := handleStreamCache(bouncer); err != nil {
-		bouncer.log.Warn(fmt.Sprintf("handleStreamTicker updateFailure:%d isCrowdsecStreamHealthy:%t %s", updateFailure, isCrowdsecStreamHealthy, err.Error()))
-		if bouncer.updateMaxFailure != -1 && updateFailure >= bouncer.updateMaxFailure && isCrowdsecStreamHealthy {
-			isCrowdsecStreamHealthy = false
-			bouncer.log.Error(fmt.Sprintf("handleStreamTicker:error updateFailure:%d %s", updateFailure, err.Error()))
+		failures := atomic.AddInt64(&updateFailure, 1)
+		healthy := atomicBoolLoad(&isCrowdsecStreamHealthy)
+		bouncer.log.Warn(fmt.Sprintf("handleStreamTicker updateFailure:%d isCrowdsecStreamHealthy:%t %s", failures-1, healthy, err.Error()))
+		if bouncer.updateMaxFailure != -1 && failures > bouncer.updateMaxFailure && healthy {
+			atomicBoolStore(&isCrowdsecStreamHealthy, false)
+			bouncer.log.Error(fmt.Sprintf("handleStreamTicker:error updateFailure:%d %s", failures-1, err.Error()))
 		}
-		updateFailure++
 	} else {
-		isCrowdsecStreamHealthy = true
-		updateFailure = 0
+		atomicBoolStore(&isCrowdsecStreamHealthy, true)
+		atomic.StoreInt64(&updateFailure, 0)
 	}
 }
 
-func streamTickerNeedsRecovery(lastRun int64, now time.Time, updateInterval int64) bool {
+func markStreamRun() {
+	atomic.StoreInt64(&lastStreamTickerRun, int64(time.Since(processStart)))
+}
+
+func streamTickerNeedsRecovery(lastRun int64, elapsed time.Duration, updateInterval int64) bool {
 	if updateInterval < 1 {
 		return false
 	}
@@ -530,25 +532,21 @@ func streamTickerNeedsRecovery(lastRun int64, now time.Time, updateInterval int6
 		return true
 	}
 
-	lastRunAt := time.Unix(0, lastRun)
-	return !now.Before(lastRunAt) && now.Sub(lastRunAt) >= 2*time.Duration(updateInterval)*time.Second
+	lastRunElapsed := time.Duration(lastRun)
+	return elapsed >= lastRunElapsed && elapsed-lastRunElapsed >= 2*time.Duration(updateInterval)*time.Second
 }
 
 func handleStreamWatchdog(bouncer *Bouncer) {
 	if bouncer.crowdsecMode != configuration.StreamMode && bouncer.crowdsecMode != configuration.AloneMode {
 		return
 	}
-	if atomic.LoadInt32(&streamUpdateInProgress) != 0 {
-		return
-	}
-
 	lastRun := atomic.LoadInt64(&lastStreamTickerRun)
-	if !streamTickerNeedsRecovery(lastRun, time.Now(), bouncer.updateInterval) {
+	if !streamTickerNeedsRecovery(lastRun, time.Since(processStart), bouncer.updateInterval) {
 		return
 	}
 
 	bouncer.log.Warn("handleStreamWatchdog: stream ticker stale, forcing a refresh")
-	handleStreamTicker(bouncer)
+	go handleStreamTicker(bouncer)
 }
 
 func handleMetricsTicker(bouncer *Bouncer) {
@@ -562,6 +560,7 @@ func startTicker(name string, updateInterval int64, log *slog.Logger, work func(
 	ticker := time.NewTicker(time.Duration(updateInterval) * time.Second)
 	stop := make(chan bool, 1)
 	go func() {
+		defer ticker.Stop()
 		defer log.Debug(name + "_ticker:stopped")
 		for {
 			select {
@@ -573,6 +572,52 @@ func startTicker(name string, updateInterval int64, log *slog.Logger, work func(
 		}
 	}()
 	return stop
+}
+
+func (runtime *tickerRuntime) startStream(bouncer *Bouncer, config *configuration.Config, log *slog.Logger) error {
+	runtime.streamOnce.Do(func() {
+		if config.CrowdsecMode == configuration.AloneMode {
+			if err := getToken(bouncer); err != nil {
+				bouncer.log.Error("New:getToken " + err.Error())
+				runtime.streamInitialization = err
+				return
+			}
+		}
+		if config.StreamStartupBlock {
+			handleStreamTicker(bouncer)
+		} else {
+			go handleStreamTicker(bouncer)
+		}
+		runtime.streamTicker = startTicker("stream", config.UpdateIntervalSeconds, log, func() {
+			handleStreamTicker(bouncer)
+		})
+		runtime.streamWatchdogTicker = startTicker("stream_watchdog", config.UpdateIntervalSeconds, log, func() {
+			handleStreamWatchdog(bouncer)
+		})
+	})
+	return runtime.streamInitialization
+}
+
+func (runtime *tickerRuntime) startMetrics(bouncer *Bouncer, config *configuration.Config, log *slog.Logger) {
+	runtime.metricsOnce.Do(func() {
+		lastMetricsPush = time.Now()
+		go handleMetricsTicker(bouncer)
+		runtime.metricsTicker = startTicker("metrics", config.MetricsUpdateIntervalSeconds, log, func() {
+			handleMetricsTicker(bouncer)
+		})
+	})
+}
+
+func stopTicker(ticker chan bool) {
+	if ticker != nil {
+		ticker <- true
+	}
+}
+
+func (runtime *tickerRuntime) stop() {
+	stopTicker(runtime.streamTicker)
+	stopTicker(runtime.streamWatchdogTicker)
+	stopTicker(runtime.metricsTicker)
 }
 
 // We are now in none or live mode.
@@ -677,7 +722,7 @@ func handleStreamCache(bouncer *Bouncer) error {
 	_, err := bouncer.cacheClient.Get(cacheTimeoutKey)
 	if err == nil {
 		bouncer.log.Debug("handleStreamCache:alreadyUpdated")
-		isCrowdsecStreamStartup = false
+		atomicBoolStore(&isCrowdsecStreamStartup, false)
 		return nil
 	}
 	if err.Error() != cache.CacheMiss {
@@ -693,7 +738,7 @@ func handleStreamCache(bouncer *Bouncer) error {
 		Scheme:   bouncer.crowdsecScheme,
 		Host:     bouncer.crowdsecHost,
 		Path:     bouncer.crowdsecPath + bouncer.crowdsecStreamRoute,
-		RawQuery: fmt.Sprintf("startup=%t", !isCrowdsecStreamHealthy || isCrowdsecStreamStartup),
+		RawQuery: fmt.Sprintf("startup=%t", !atomicBoolLoad(&isCrowdsecStreamHealthy) || atomicBoolLoad(&isCrowdsecStreamStartup)),
 	}
 	body, err := crowdsecQuery(bouncer, streamRouteURL.String(), nil)
 	if err != nil {
@@ -723,7 +768,7 @@ func handleStreamCache(bouncer *Bouncer) error {
 		bouncer.cacheClient.Delete(decision.Value)
 	}
 	bouncer.log.Debug("handleStreamCache:updated")
-	isCrowdsecStreamStartup = false
+	atomicBoolStore(&isCrowdsecStreamStartup, false)
 	return nil
 }
 

--- a/bouncer_test.go
+++ b/bouncer_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"text/template"
@@ -22,6 +23,7 @@ import (
 func TestServeHTTP(t *testing.T) {
 	cfg := CreateConfig()
 	cfg.CrowdsecLapiKey = "test"
+	cfg.MetricsUpdateIntervalSeconds = 0
 
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
@@ -166,7 +168,7 @@ func Test_handleStreamCache(t *testing.T) {
 }
 
 func Test_streamTickerNeedsRecovery(t *testing.T) {
-	now := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
+	elapsed := 10 * time.Minute
 	tests := []struct {
 		name           string
 		lastRun        int64
@@ -174,59 +176,77 @@ func Test_streamTickerNeedsRecovery(t *testing.T) {
 		want           bool
 	}{
 		{name: "missing heartbeat", lastRun: 0, updateInterval: 60, want: true},
-		{name: "fresh heartbeat", lastRun: now.Add(-119 * time.Second).UnixNano(), updateInterval: 60, want: false},
-		{name: "threshold reached", lastRun: now.Add(-120 * time.Second).UnixNano(), updateInterval: 60, want: true},
-		{name: "stale heartbeat", lastRun: now.Add(-20 * time.Minute).UnixNano(), updateInterval: 60, want: true},
-		{name: "clock moved backwards", lastRun: now.Add(time.Second).UnixNano(), updateInterval: 60, want: false},
+		{name: "fresh heartbeat", lastRun: int64(elapsed - 119*time.Second), updateInterval: 60, want: false},
+		{name: "threshold reached", lastRun: int64(elapsed - 120*time.Second), updateInterval: 60, want: true},
+		{name: "stale heartbeat", lastRun: int64(elapsed - 5*time.Minute), updateInterval: 60, want: true},
+		{name: "elapsed precedes heartbeat", lastRun: int64(elapsed + time.Second), updateInterval: 60, want: false},
 		{name: "invalid interval", lastRun: 0, updateInterval: 0, want: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := streamTickerNeedsRecovery(tt.lastRun, now, tt.updateInterval); got != tt.want {
+			if got := streamTickerNeedsRecovery(tt.lastRun, elapsed, tt.updateInterval); got != tt.want {
 				t.Errorf("streamTickerNeedsRecovery() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func Test_handleStreamWatchdogRecoversStaleTicker(t *testing.T) {
-	previousStartup := isCrowdsecStreamStartup
-	previousHealthy := isCrowdsecStreamHealthy
-	previousUpdateFailure := updateFailure
+func isolateStreamTestState(t *testing.T, cacheClient *cache.Client) {
+	t.Helper()
+	previousStartup := atomic.LoadInt32(&isCrowdsecStreamStartup)
+	previousHealthy := atomic.LoadInt32(&isCrowdsecStreamHealthy)
+	previousUpdateFailure := atomic.LoadInt64(&updateFailure)
 	previousLastRun := atomic.LoadInt64(&lastStreamTickerRun)
-	previousInProgress := atomic.LoadInt32(&streamUpdateInProgress)
+	cacheClient.Delete(cacheTimeoutKey)
+	atomic.StoreInt32(&isCrowdsecStreamStartup, 1)
+	atomic.StoreInt32(&isCrowdsecStreamHealthy, 1)
+	atomic.StoreInt64(&updateFailure, 0)
+	atomic.StoreInt64(&lastStreamTickerRun, 0)
+	t.Cleanup(func() {
+		cacheClient.Delete(cacheTimeoutKey)
+		atomic.StoreInt32(&isCrowdsecStreamStartup, previousStartup)
+		atomic.StoreInt32(&isCrowdsecStreamHealthy, previousHealthy)
+		atomic.StoreInt64(&updateFailure, previousUpdateFailure)
+		atomic.StoreInt64(&lastStreamTickerRun, previousLastRun)
+	})
+}
 
-	var requests int32
-	lapi := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		if req.URL.Path != "/v1/decisions/stream" {
-			t.Errorf("unexpected LAPI path: %s", req.URL.Path)
+func waitForRequest(t *testing.T, requests <-chan int32, want int32) {
+	t.Helper()
+	select {
+	case got := <-requests:
+		if got != want {
+			t.Fatalf("LAPI request number = %d, want %d", got, want)
 		}
-		atomic.AddInt32(&requests, 1)
-		rw.Header().Set("Content-Type", "application/json")
-		_, _ = rw.Write([]byte(`{"deleted":[],"new":[]}`))
-	}))
-	t.Cleanup(lapi.Close)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for LAPI request %d", want)
+	}
+}
 
+func markStreamRunStaleForTest(updateInterval int64) {
+	threshold := 2 * time.Duration(updateInterval) * time.Second
+	if remaining := threshold - time.Since(processStart); remaining >= 0 {
+		time.Sleep(remaining + 10*time.Millisecond)
+	}
+	atomic.StoreInt64(&lastStreamTickerRun, 1)
+}
+
+func newStreamTestBouncer(t *testing.T, handler http.Handler, updateInterval int64) (*Bouncer, *httptest.Server) {
+	t.Helper()
+	lapi := httptest.NewServer(handler)
 	lapiURL, err := url.Parse(lapi.URL)
 	if err != nil {
+		lapi.Close()
 		t.Fatal(err)
 	}
 
 	log := logger.New("ERROR", "")
 	cacheClient := &cache.Client{}
 	cacheClient.New(log, false, "", nil, "", "")
-	cacheClient.Delete(cacheTimeoutKey)
-	t.Cleanup(func() {
-		cacheClient.Delete(cacheTimeoutKey)
-		isCrowdsecStreamStartup = previousStartup
-		isCrowdsecStreamHealthy = previousHealthy
-		updateFailure = previousUpdateFailure
-		atomic.StoreInt64(&lastStreamTickerRun, previousLastRun)
-		atomic.StoreInt32(&streamUpdateInProgress, previousInProgress)
-	})
+	isolateStreamTestState(t, cacheClient)
 
-	bouncer := &Bouncer{
+	return &Bouncer{
 		crowdsecMode:        configuration.StreamMode,
 		crowdsecScheme:      lapiURL.Scheme,
 		crowdsecHost:        lapiURL.Host,
@@ -234,28 +254,130 @@ func Test_handleStreamWatchdogRecoversStaleTicker(t *testing.T) {
 		crowdsecKey:         "test",
 		crowdsecStreamRoute: crowdsecLapiStreamRoute,
 		crowdsecHeader:      crowdsecLapiHeader,
-		updateInterval:      60,
+		updateInterval:      updateInterval,
 		updateMaxFailure:    0,
 		httpClient:          lapi.Client(),
 		cacheClient:         cacheClient,
 		log:                 log,
-	}
+	}, lapi
+}
 
-	atomic.StoreInt64(&lastStreamTickerRun, time.Now().Add(-2*time.Minute).UnixNano())
-	atomic.StoreInt32(&streamUpdateInProgress, 1)
-	handleStreamWatchdog(bouncer)
-	if got := atomic.LoadInt32(&requests); got != 0 {
-		t.Fatalf("watchdog sent %d LAPI requests while an update was in progress, want 0", got)
-	}
+func Test_handleStreamTickerContinuesPastWedgedRefresh(t *testing.T) {
+	requests := make(chan int32, 4)
+	releaseFirst := make(chan struct{})
+	var requestCount int32
+	bouncer, lapi := newStreamTestBouncer(t, http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/v1/decisions/stream" {
+			t.Errorf("unexpected LAPI path: %s", req.URL.Path)
+		}
+		current := atomic.AddInt32(&requestCount, 1)
+		requests <- current
+		if current == 1 {
+			<-releaseFirst
+		}
+		rw.Header().Set("Content-Type", "application/json")
+		_, _ = rw.Write([]byte(`{"deleted":[],"new":[]}`))
+	}), 1)
+	defer lapi.Close()
+	defer close(releaseFirst)
 
-	atomic.StoreInt32(&streamUpdateInProgress, 0)
+	go handleStreamTicker(bouncer)
+	waitForRequest(t, requests, 1)
+
+	// The first refresh remains wedged. Once its one-second cache lease expires,
+	// a later tick must still reach LAPI instead of being suppressed by a latch.
+	time.Sleep(1100 * time.Millisecond)
+	go handleStreamTicker(bouncer)
+	waitForRequest(t, requests, 2)
+
+	// The watchdog must retain the same property while the first refresh is
+	// still outstanding.
+	time.Sleep(1100 * time.Millisecond)
+	markStreamRunStaleForTest(bouncer.updateInterval)
 	handleStreamWatchdog(bouncer)
+	waitForRequest(t, requests, 3)
+}
+
+func Test_tickerRuntimeStartsStreamLoopsOnce(t *testing.T) {
+	var requests int32
+	bouncer, lapi := newStreamTestBouncer(t, http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		rw.Header().Set("Content-Type", "application/json")
+		_, _ = rw.Write([]byte(`{"deleted":[],"new":[]}`))
+	}), 3600)
+	defer lapi.Close()
+
+	config := configuration.New()
+	config.CrowdsecMode = configuration.StreamMode
+	config.UpdateIntervalSeconds = 3600
+	config.StreamStartupBlock = true
+	config.MetricsUpdateIntervalSeconds = 0
+
+	var runtime tickerRuntime
+	defer runtime.stop()
+	var wg sync.WaitGroup
+	errors := make(chan error, 16)
+	// Yaegi v0.16.1 does not support Go 1.22 integer ranges yet.
+	//nolint:intrange
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errors <- runtime.startStream(bouncer, config, bouncer.log)
+		}()
+	}
+	wg.Wait()
+	close(errors)
+	for err := range errors {
+		if err != nil {
+			t.Fatalf("startStream() error = %v", err)
+		}
+	}
 
 	if got := atomic.LoadInt32(&requests); got != 1 {
-		t.Fatalf("watchdog sent %d LAPI requests, want 1", got)
+		t.Fatalf("stream initialization made %d LAPI requests, want 1", got)
 	}
-	if streamTickerNeedsRecovery(atomic.LoadInt64(&lastStreamTickerRun), time.Now(), bouncer.updateInterval) {
-		t.Fatal("stream ticker heartbeat remained stale after watchdog recovery")
+	if runtime.streamTicker == nil || runtime.streamWatchdogTicker == nil {
+		t.Fatal("stream runtime did not retain both ticker stop channels")
+	}
+}
+
+func Test_handleMetricsTickerDoesNotWaitForStreamRecovery(t *testing.T) {
+	streamStarted := make(chan struct{}, 1)
+	metricsReported := make(chan struct{}, 1)
+	releaseStream := make(chan struct{})
+	bouncer, lapi := newStreamTestBouncer(t, http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v1/decisions/stream":
+			streamStarted <- struct{}{}
+			<-releaseStream
+			rw.Header().Set("Content-Type", "application/json")
+			_, _ = rw.Write([]byte(`{"deleted":[],"new":[]}`))
+		case "/v1/usage-metrics":
+			metricsReported <- struct{}{}
+			rw.WriteHeader(http.StatusCreated)
+		default:
+			t.Errorf("unexpected LAPI path: %s", req.URL.Path)
+		}
+	}), 1)
+	defer lapi.Close()
+	defer close(releaseStream)
+
+	previousLastMetricsPush := lastMetricsPush
+	defer func() { lastMetricsPush = previousLastMetricsPush }()
+	lastMetricsPush = time.Now().Add(-time.Minute)
+	markStreamRunStaleForTest(bouncer.updateInterval)
+	handleMetricsTicker(bouncer)
+
+	select {
+	case <-metricsReported:
+	case <-time.After(time.Second):
+		t.Fatal("metrics report waited for the forced stream refresh")
+	}
+	select {
+	case <-streamStarted:
+	case <-time.After(time.Second):
+		t.Fatal("watchdog did not start the asynchronous stream refresh")
 	}
 }
 

--- a/bouncer_test.go
+++ b/bouncer_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"text/template"
 	"time"
@@ -161,6 +162,100 @@ func Test_handleStreamCache(t *testing.T) {
 				return
 			}
 		})
+	}
+}
+
+func Test_streamTickerNeedsRecovery(t *testing.T) {
+	now := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name           string
+		lastRun        int64
+		updateInterval int64
+		want           bool
+	}{
+		{name: "missing heartbeat", lastRun: 0, updateInterval: 60, want: true},
+		{name: "fresh heartbeat", lastRun: now.Add(-119 * time.Second).UnixNano(), updateInterval: 60, want: false},
+		{name: "threshold reached", lastRun: now.Add(-120 * time.Second).UnixNano(), updateInterval: 60, want: true},
+		{name: "stale heartbeat", lastRun: now.Add(-20 * time.Minute).UnixNano(), updateInterval: 60, want: true},
+		{name: "clock moved backwards", lastRun: now.Add(time.Second).UnixNano(), updateInterval: 60, want: false},
+		{name: "invalid interval", lastRun: 0, updateInterval: 0, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := streamTickerNeedsRecovery(tt.lastRun, now, tt.updateInterval); got != tt.want {
+				t.Errorf("streamTickerNeedsRecovery() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_handleStreamWatchdogRecoversStaleTicker(t *testing.T) {
+	previousStartup := isCrowdsecStreamStartup
+	previousHealthy := isCrowdsecStreamHealthy
+	previousUpdateFailure := updateFailure
+	previousLastRun := atomic.LoadInt64(&lastStreamTickerRun)
+	previousInProgress := atomic.LoadInt32(&streamUpdateInProgress)
+
+	var requests int32
+	lapi := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/v1/decisions/stream" {
+			t.Errorf("unexpected LAPI path: %s", req.URL.Path)
+		}
+		atomic.AddInt32(&requests, 1)
+		rw.Header().Set("Content-Type", "application/json")
+		_, _ = rw.Write([]byte(`{"deleted":[],"new":[]}`))
+	}))
+	t.Cleanup(lapi.Close)
+
+	lapiURL, err := url.Parse(lapi.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log := logger.New("ERROR", "")
+	cacheClient := &cache.Client{}
+	cacheClient.New(log, false, "", nil, "", "")
+	cacheClient.Delete(cacheTimeoutKey)
+	t.Cleanup(func() {
+		cacheClient.Delete(cacheTimeoutKey)
+		isCrowdsecStreamStartup = previousStartup
+		isCrowdsecStreamHealthy = previousHealthy
+		updateFailure = previousUpdateFailure
+		atomic.StoreInt64(&lastStreamTickerRun, previousLastRun)
+		atomic.StoreInt32(&streamUpdateInProgress, previousInProgress)
+	})
+
+	bouncer := &Bouncer{
+		crowdsecMode:        configuration.StreamMode,
+		crowdsecScheme:      lapiURL.Scheme,
+		crowdsecHost:        lapiURL.Host,
+		crowdsecPath:        "/",
+		crowdsecKey:         "test",
+		crowdsecStreamRoute: crowdsecLapiStreamRoute,
+		crowdsecHeader:      crowdsecLapiHeader,
+		updateInterval:      60,
+		updateMaxFailure:    0,
+		httpClient:          lapi.Client(),
+		cacheClient:         cacheClient,
+		log:                 log,
+	}
+
+	atomic.StoreInt64(&lastStreamTickerRun, time.Now().Add(-2*time.Minute).UnixNano())
+	atomic.StoreInt32(&streamUpdateInProgress, 1)
+	handleStreamWatchdog(bouncer)
+	if got := atomic.LoadInt32(&requests); got != 0 {
+		t.Fatalf("watchdog sent %d LAPI requests while an update was in progress, want 0", got)
+	}
+
+	atomic.StoreInt32(&streamUpdateInProgress, 0)
+	handleStreamWatchdog(bouncer)
+
+	if got := atomic.LoadInt32(&requests); got != 1 {
+		t.Fatalf("watchdog sent %d LAPI requests, want 1", got)
+	}
+	if streamTickerNeedsRecovery(atomic.LoadInt64(&lastStreamTickerRun), time.Now(), bouncer.updateInterval) {
+		t.Fatal("stream ticker heartbeat remained stale after watchdog recovery")
 	}
 }
 


### PR DESCRIPTION
## Summary

- record a heartbeat whenever the stream refresh routine starts
- recover a stale stream scheduler after two configured update intervals
- use both a dedicated watchdog ticker and the independent metrics path as recovery triggers
- serialize refreshes so a recovery cannot overlap a healthy or already-running stream update

## Context

This is a bounded liveness mitigation for #377. The issue has now been reproduced on both ARM64 and AMD64: the normal decisions-stream requests stop silently while Traefik, CrowdSec heartbeat traffic, and usage-metrics reporting remain healthy.

The evidence does not yet prove why the stream scheduler becomes silent, so this patch deliberately does not claim a speculative root cause. Instead, it makes the failure bounded: under normal operation the watchdog is a no-op; after two missed intervals it forces one refresh. The metrics ticker provides a second, independently observed recovery path if the dedicated watchdog is also delayed.

## Safety properties

- no configuration or API changes
- no additional LAPI request while the stream heartbeat is fresh
- no concurrent stream refresh while another refresh is in progress
- the existing HTTP client timeout and stream health handling remain unchanged
- cached decisions remain available throughout recovery

## Validation

- `GOTOOLCHAIN=go1.22.12 go test ./...`
- `go test -race ./...`
- `golangci-lint v1.63.4 run`
- `yaegi v0.16.1 test .`
- full binary/mock E2E suite with Traefik v3.7.11: AppSec, captcha, custom ban page, live mode, none mode, Redis, stream mode, system CA, and trusted IPs

Refs #377
