### PR TITLE
🐛 do not drop bodyless DELETE over HTTP/3

### DIFF
--- a/bouncer.go
+++ b/bouncer.go
@@ -746,7 +746,7 @@ func isBodyUnreadable(httpReq *http.Request) bool {
 // isMethodWithBody used only when isBodyUnreadable returns true but the request method can't have body.
 func isMethodWithBody(method string) bool {
 	switch method {
-	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+	case http.MethodPost, http.MethodPut, http.MethodPatch:
 		return true
 	default:
 		return false

--- a/bouncer_test.go
+++ b/bouncer_test.go
@@ -514,13 +514,6 @@ func Test_appsecQuery_dropUnreadableBody(t *testing.T) {
 	}
 }
 
-func newUnreadableGetRequest(done <-chan struct{}) *http.Request {
-	req, _ := http.NewRequest(http.MethodGet, "http://localhost/", blockingBody{done: done})
-	req.ProtoMajor = 3
-	req.ContentLength = -1
-	return req
-}
-
 // Test_appsecQuery_unreadableBodyGetNotDropped is a regression test for issue #351
 func Test_appsecQuery_unreadableBodyGetNotDropped(t *testing.T) {
 	appsecServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
@@ -544,7 +537,7 @@ func Test_appsecQuery_unreadableBodyGetNotDropped(t *testing.T) {
 
 	finished := make(chan error, 1)
 	go func() {
-		finished <- appsecQuery(bouncer, "1.2.3.4", newUnreadableGetRequest(done))
+		finished <- appsecQuery(bouncer, "1.2.3.4", newUnreadableRequest(http.MethodGet, done))
 	}()
 
 	select {

--- a/bouncer_test.go
+++ b/bouncer_test.go
@@ -600,3 +600,66 @@ func Test_appsecQuery_reusesConnection(t *testing.T) {
 		})
 	}
 }
+
+func newUnreadableRequest(method string, done <-chan struct{}) *http.Request {
+	req, _ := http.NewRequest(method, "http://localhost/api/admin/reservations/8fff14a2", blockingBody{done: done})
+	req.ProtoMajor = 3
+	req.ContentLength = -1
+	return req
+}
+
+func Test_appsecQuery_unreadableBodyMethods(t *testing.T) {
+	appsecServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer appsecServer.Close()
+
+	appsecURL, _ := url.Parse(appsecServer.URL)
+
+	tests := []struct {
+		method      string
+		wantDropped bool
+	}{
+		{method: http.MethodGet, wantDropped: false},
+		{method: http.MethodHead, wantDropped: false},
+		{method: http.MethodOptions, wantDropped: false},
+		{method: http.MethodDelete, wantDropped: false},
+		{method: http.MethodPost, wantDropped: true},
+		{method: http.MethodPut, wantDropped: true},
+		{method: http.MethodPatch, wantDropped: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			bouncer := &Bouncer{
+				appsecScheme:              appsecURL.Scheme,
+				appsecHost:                appsecURL.Host,
+				appsecPath:                "/",
+				appsecBodyLimit:           10485760,
+				appsecUnreadableBodyBlock: true,
+				httpAppsecClient:          appsecServer.Client(),
+				log:                       logger.New("INFO", ""),
+			}
+
+			done := make(chan struct{})
+			defer close(done)
+
+			finished := make(chan error, 1)
+			go func() {
+				finished <- appsecQuery(bouncer, "1.2.3.4", newUnreadableRequest(tt.method, done))
+			}()
+
+			select {
+			case err := <-finished:
+				if tt.wantDropped && err == nil {
+					t.Errorf("appsecQuery() on an unreadable-body %s: expected the request to be dropped, got nil", tt.method)
+				}
+				if !tt.wantDropped && err != nil {
+					t.Errorf("appsecQuery() on a bodyless HTTP/3 %s returned error: %v", tt.method, err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("appsecQuery() blocked on an unreadable %s body", tt.method)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fix #385.

### The bug

A bodyless `DELETE` over HTTP/3 is answered with a 403 from the bouncer, while the identical request over HTTP/2 succeeds.

### Why HTTP/3 differs from HTTP/2

`isBodyUnreadable` keys off `ContentLength < 0`, and the two servers populate that field differently.

Go's HTTP/2 server only treats the length as unknown when the client actually left the stream open for DATA frames (`x/net/http2/server.go`):

```go
bodyOpen := !f.StreamEnded()
if bodyOpen {
    ...
    req.ContentLength = -1
}
```

A request that ends at the headers therefore keeps `ContentLength == 0`, and `isBodyUnreadable` is false.

quic-go has no equivalent signal. `http3/server_conn.go` assigns the body unconditionally:

```go
body := newRequestBody(hstr, contentLength, ...)
req.Body = body
```

and `http3/headers.go` defaults `ContentLength` to `-1` whenever the `Content-Length` header is absent. So on HTTP/3 **every** bodyless request satisfies `isBodyUnreadable`, whatever its method — `isMethodWithBody` is the only thing standing between the plugin and a blanket 403.

That makes `DELETE` the visible casualty: `fetch(url, { method: "DELETE" })` sends no body and no `Content-Length`, so it is dropped on HTTP/3 and fine on HTTP/2.

### The change

Remove `DELETE` from `isMethodWithBody`.

- A `DELETE` body is legal but has no defined semantics (RFC 9110 §9.3.5).
- The gRPC bidirectional streams that #323/#332 protect against are always `POST`, so that protection is untouched — `POST`, `PUT` and `PATCH` still drop.
- @dani raised this on #352 before it merged; this closes it.

**This diverges from the reference implementation**, and that is deliberate rather than an oversight: `lua-cs-bouncer`'s `METHODS_WITH_BODY` (lib/crowdsec.lua) still lists `DELETE`, and its `get_body()` bails on the same `http_version >= 2 && no Content-Length` condition, so the same false positive likely exists there and is worth reporting upstream. If you would rather stay aligned with the reference, the alternative is to make the method set configurable and leave the default alone — happy to switch to that instead.

### Tests

`isMethodWithBody` had no direct coverage; the existing `DELETE` tests cover ban templates and captcha remediation. Added `Test_appsecQuery_unreadableBodyMethods`, which pins all seven methods against a request shaped exactly like quic-go's (`ProtoMajor: 3`, `ContentLength: -1`, non-nil blocking body).

It fails on the current code:

```
--- FAIL: Test_appsecQuery_unreadableBodyMethods/DELETE
    appsecQuery() on a bodyless HTTP/3 DELETE returned error: appsecQuery:unreadableBody dropped
```

and passes with the change. Full suite, `go vet` and `gofmt` are clean.
