### PR TITLE
🐛 drain the appsec response body so connections are reused

### DIFF
--- a/bouncer.go
+++ b/bouncer.go
@@ -243,19 +243,17 @@ func New(_ context.Context, next http.Handler, config *configuration.Config, nam
 		},
 		httpClient: &http.Client{
 			Transport: &http.Transport{
-				MaxIdleConns:        10,
-				MaxIdleConnsPerHost: 10,
-				IdleConnTimeout:     30 * time.Second,
-				TLSClientConfig:     tlsConfig,
+				MaxIdleConns:    10,
+				IdleConnTimeout: 30 * time.Second,
+				TLSClientConfig: tlsConfig,
 			},
 			Timeout: time.Duration(config.HTTPTimeoutSeconds) * time.Second,
 		},
 		httpAppsecClient: &http.Client{
 			Transport: &http.Transport{
-				MaxIdleConns:        10,
-				MaxIdleConnsPerHost: 10,
-				IdleConnTimeout:     30 * time.Second,
-				TLSClientConfig:     tlsAppsecConfig,
+				MaxIdleConns:    10,
+				IdleConnTimeout: 30 * time.Second,
+				TLSClientConfig: tlsAppsecConfig,
 			},
 			Timeout: time.Duration(config.HTTPTimeoutSeconds) * time.Second,
 		},
@@ -280,7 +278,7 @@ func New(_ context.Context, next http.Handler, config *configuration.Config, nam
 		log,
 		bouncer.cacheClient,
 		&http.Client{
-			Transport: &http.Transport{MaxIdleConns: 10, MaxIdleConnsPerHost: 10, IdleConnTimeout: 30 * time.Second},
+			Transport: &http.Transport{MaxIdleConns: 10, IdleConnTimeout: 30 * time.Second},
 			Timeout:   time.Duration(config.HTTPTimeoutSeconds) * time.Second,
 		},
 		config.CaptchaProvider,
@@ -803,13 +801,6 @@ func appsecQuery(bouncer *Bouncer, ip string, httpReq *http.Request) error {
 		return nil
 	}
 	defer func() {
-		// net/http only returns a connection to the idle pool once its body has
-		// been read to EOF; closing early discards it. Drain here rather than at
-		// the end of the function so the 500 and non-200 paths, which return
-		// earlier, keep their connections too.
-		if _, errDrain := io.Copy(io.Discard, res.Body); errDrain != nil {
-			bouncer.log.Debug("appsecQuery:drainBody " + errDrain.Error())
-		}
 		if err = res.Body.Close(); err != nil {
 			bouncer.log.Error("appsecQuery:closeBody " + err.Error())
 		}
@@ -825,6 +816,9 @@ func appsecQuery(bouncer *Bouncer, ip string, httpReq *http.Request) error {
 		return fmt.Errorf("appsecQuery statusCode:%d", res.StatusCode)
 	}
 
+	if err != nil {
+		return fmt.Errorf("appsecQuery:readBody %w", err)
+	}
 	return nil
 }
 

--- a/bouncer.go
+++ b/bouncer.go
@@ -803,10 +803,8 @@ func appsecQuery(bouncer *Bouncer, ip string, httpReq *http.Request) error {
 		return nil
 	}
 	defer func() {
-		// net/http only returns a connection to the idle pool once its body has
-		// been read to EOF; closing early discards it. Drain here rather than at
-		// the end of the function so the 500 and non-200 paths, which return
-		// earlier, keep their connections too.
+		// net/http returns a conn to the idle pool once its body has been read to EOF, closing early discards it.
+		// Drain the body from the non-200 paths, which return earlier, keep their connections too.
 		if _, errDrain := io.Copy(io.Discard, res.Body); errDrain != nil {
 			bouncer.log.Debug("appsecQuery:drainBody " + errDrain.Error())
 		}

--- a/bouncer.go
+++ b/bouncer.go
@@ -243,17 +243,19 @@ func New(_ context.Context, next http.Handler, config *configuration.Config, nam
 		},
 		httpClient: &http.Client{
 			Transport: &http.Transport{
-				MaxIdleConns:    10,
-				IdleConnTimeout: 30 * time.Second,
-				TLSClientConfig: tlsConfig,
+				MaxIdleConns:        10,
+				MaxIdleConnsPerHost: 10,
+				IdleConnTimeout:     30 * time.Second,
+				TLSClientConfig:     tlsConfig,
 			},
 			Timeout: time.Duration(config.HTTPTimeoutSeconds) * time.Second,
 		},
 		httpAppsecClient: &http.Client{
 			Transport: &http.Transport{
-				MaxIdleConns:    10,
-				IdleConnTimeout: 30 * time.Second,
-				TLSClientConfig: tlsAppsecConfig,
+				MaxIdleConns:        10,
+				MaxIdleConnsPerHost: 10,
+				IdleConnTimeout:     30 * time.Second,
+				TLSClientConfig:     tlsAppsecConfig,
 			},
 			Timeout: time.Duration(config.HTTPTimeoutSeconds) * time.Second,
 		},
@@ -278,7 +280,7 @@ func New(_ context.Context, next http.Handler, config *configuration.Config, nam
 		log,
 		bouncer.cacheClient,
 		&http.Client{
-			Transport: &http.Transport{MaxIdleConns: 10, IdleConnTimeout: 30 * time.Second},
+			Transport: &http.Transport{MaxIdleConns: 10, MaxIdleConnsPerHost: 10, IdleConnTimeout: 30 * time.Second},
 			Timeout:   time.Duration(config.HTTPTimeoutSeconds) * time.Second,
 		},
 		config.CaptchaProvider,
@@ -801,6 +803,13 @@ func appsecQuery(bouncer *Bouncer, ip string, httpReq *http.Request) error {
 		return nil
 	}
 	defer func() {
+		// net/http only returns a connection to the idle pool once its body has
+		// been read to EOF; closing early discards it. Drain here rather than at
+		// the end of the function so the 500 and non-200 paths, which return
+		// earlier, keep their connections too.
+		if _, errDrain := io.Copy(io.Discard, res.Body); errDrain != nil {
+			bouncer.log.Debug("appsecQuery:drainBody " + errDrain.Error())
+		}
 		if err = res.Body.Close(); err != nil {
 			bouncer.log.Error("appsecQuery:closeBody " + err.Error())
 		}
@@ -816,9 +825,6 @@ func appsecQuery(bouncer *Bouncer, ip string, httpReq *http.Request) error {
 		return fmt.Errorf("appsecQuery statusCode:%d", res.StatusCode)
 	}
 
-	if err != nil {
-		return fmt.Errorf("appsecQuery:readBody %w", err)
-	}
 	return nil
 }
 

--- a/bouncer_test.go
+++ b/bouncer_test.go
@@ -2,7 +2,6 @@ package crowdsec_bouncer_traefik_plugin //nolint:revive,stylecheck
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -576,7 +575,9 @@ func Test_appsecQuery_reusesConnection(t *testing.T) {
 				rw.WriteHeader(status)
 				// a non-empty body is what makes the connection unusable when it
 				// is not drained; an empty one is already at EOF
-				fmt.Fprint(rw, `{"action":"allow"}`)
+				if _, errWrite := rw.Write([]byte(`{"action":"allow"}`)); errWrite != nil {
+					t.Errorf("appsec stub write: %v", errWrite)
+				}
 			}))
 			defer appsecServer.Close()
 

--- a/bouncer_test.go
+++ b/bouncer_test.go
@@ -593,7 +593,10 @@ func Test_appsecQuery_reusesConnection(t *testing.T) {
 			}
 
 			const calls = 10
-			for range calls {
+			// Not a range-over-int loop: yaegi v0.16.1, which is what Traefik
+			// bundles and what `make yaegi_test` pins, cannot parse that form
+			// and panics with "nil type".
+			for i := 0; i < calls; i++ { //nolint:intrange
 				req, _ := http.NewRequest(http.MethodGet, "http://localhost/", nil)
 				_ = appsecQuery(bouncer, "1.2.3.4", req)
 			}

--- a/bouncer_test.go
+++ b/bouncer_test.go
@@ -557,12 +557,8 @@ func Test_appsecQuery_unreadableBodyGetNotDropped(t *testing.T) {
 	}
 }
 
-// Test_appsecQuery_reusesConnection is a regression test for issue #384: the
-// appsec response body must be drained so net/http can return the connection to
-// the idle pool. Without it every request opened a fresh TCP connection and left
-// it in TIME_WAIT. The 403 and 500 cases matter as much as 200: they return
-// before the end of the function, and they are what a site under attack or a
-// wedged appsec produce in volume.
+// Test_appsecQuery_reusesConnection is a regression test for issue #384: the appsec response
+// body must be drained for non-200 status response so net/http can return the conn to the idle pool.
 func Test_appsecQuery_reusesConnection(t *testing.T) {
 	for _, status := range []int{http.StatusOK, http.StatusForbidden, http.StatusInternalServerError} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
@@ -573,8 +569,6 @@ func Test_appsecQuery_reusesConnection(t *testing.T) {
 				conns[r.RemoteAddr] = true
 				mu.Unlock()
 				rw.WriteHeader(status)
-				// a non-empty body is what makes the connection unusable when it
-				// is not drained; an empty one is already at EOF
 				if _, errWrite := rw.Write([]byte(`{"action":"allow"}`)); errWrite != nil {
 					t.Errorf("appsec stub write: %v", errWrite)
 				}
@@ -593,9 +587,6 @@ func Test_appsecQuery_reusesConnection(t *testing.T) {
 			}
 
 			const calls = 10
-			// Not a range-over-int loop: yaegi v0.16.1, which is what Traefik
-			// bundles and what `make yaegi_test` pins, cannot parse that form
-			// and panics with "nil type".
 			for i := 0; i < calls; i++ { //nolint:intrange
 				req, _ := http.NewRequest(http.MethodGet, "http://localhost/", nil)
 				_ = appsecQuery(bouncer, "1.2.3.4", req)

--- a/bouncer_test.go
+++ b/bouncer_test.go
@@ -2,12 +2,14 @@ package crowdsec_bouncer_traefik_plugin //nolint:revive,stylecheck
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"text/template"
 	"time"
@@ -553,5 +555,53 @@ func Test_appsecQuery_unreadableBodyGetNotDropped(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("appsecQuery() blocked on an HTTP/3 GET request body (issue #351 regression)")
+	}
+}
+
+// Test_appsecQuery_reusesConnection is a regression test for issue #384: the
+// appsec response body must be drained so net/http can return the connection to
+// the idle pool. Without it every request opened a fresh TCP connection and left
+// it in TIME_WAIT. The 403 and 500 cases matter as much as 200: they return
+// before the end of the function, and they are what a site under attack or a
+// wedged appsec produce in volume.
+func Test_appsecQuery_reusesConnection(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusForbidden, http.StatusInternalServerError} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var mu sync.Mutex
+			conns := map[string]bool{}
+			appsecServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				conns[r.RemoteAddr] = true
+				mu.Unlock()
+				rw.WriteHeader(status)
+				// a non-empty body is what makes the connection unusable when it
+				// is not drained; an empty one is already at EOF
+				fmt.Fprint(rw, `{"action":"allow"}`)
+			}))
+			defer appsecServer.Close()
+
+			appsecURL, _ := url.Parse(appsecServer.URL)
+			bouncer := &Bouncer{
+				appsecScheme:       appsecURL.Scheme,
+				appsecHost:         appsecURL.Host,
+				appsecPath:         "/",
+				appsecBodyLimit:    10485760,
+				appsecFailureBlock: false,
+				httpAppsecClient:   appsecServer.Client(),
+				log:                logger.New("INFO", ""),
+			}
+
+			const calls = 10
+			for range calls {
+				req, _ := http.NewRequest(http.MethodGet, "http://localhost/", nil)
+				_ = appsecQuery(bouncer, "1.2.3.4", req)
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			if len(conns) != 1 {
+				t.Errorf("appsecQuery() opened %d connections for %d calls, want 1 (response body not drained?)", len(conns), calls)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fix #384. Thanks @shockstricken — the socket-table evidence made this straightforward to confirm.

### The bug

`appsecQuery` never read the appsec response body. `net/http` only returns a connection to the idle pool once its body has reached EOF; closing early discards it. So every request opened a fresh TCP connection to the appsec host and left it in `TIME_WAIT`. `crowdsecQuery`, two functions above, *does* call `io.ReadAll`, which is why the LAPI path in the same process pools correctly — a clean control.

Reproduced with an httptest appsec server, counting distinct `RemoteAddr` over 10 calls:

| appsec response body | connections for 10 calls |
| --- | --- |
| empty | 1 (already at EOF, reuse worked) |
| non-empty `{"action":"allow"}` | **10** |

Worth noting for anyone trying to reproduce: with an empty response body the connection *is* reused, so a stub that answers `200` with no content will not show the problem.

### Where the drain goes

The issue proposes draining before the final `return nil`. That fixes the 200 path only — the `500` and non-`200` paths return earlier and never reach it:

| | drain before final `return nil` | drain in the `defer` |
| --- | --- | --- |
| 200 | 1 connection | 1 connection |
| 403 | **10 connections** | 1 connection |
| 500 | **10 connections** | 1 connection |

That is the wrong half to fix: `403` is what appsec produces for a site under attack, and `500` is what a wedged appsec produces — precisely when connection churn hurts. So the drain lives in the existing `defer`, before `Close()`, covering every return path in one place.

### Also in this PR

- Removes the unreachable `if err != nil { return fmt.Errorf("appsecQuery:readBody %w", err) }`. As the issue says, `err` is always `nil` there. It is worth deleting rather than repurposing: the deferred `res.Body.Close()` assigns to that same `err`, which is harmless only because the return is unnamed — a trap for a later edit.
- Sets `MaxIdleConnsPerHost: 10` on the three transports. Each client talks to exactly one host, so the unset default of `2` (`DefaultMaxIdleConnsPerHost`) capped the pool well below the configured `MaxIdleConns: 10`. I included the captcha client for consistency; happy to drop that hunk if you would rather keep this to the two the issue names.

### Test

`Test_appsecQuery_reusesConnection` asserts one connection for ten calls across `200`/`403`/`500`. It fails on the previous code:

```
--- FAIL: Test_appsecQuery_reusesConnection/OK
    appsecQuery() opened 10 connections for 10 calls, want 1 (response body not drained?)
--- FAIL: Test_appsecQuery_reusesConnection/Forbidden
    appsecQuery() opened 10 connections for 10 calls, want 1 (response body not drained?)
```

It asserts on connection counts rather than behaviour, which is a little unusual for this suite — if you would prefer not to carry it, the fix stands on its own and the hunk is easy to drop.

Full suite, `go vet` and `gofmt` are clean.

### Not addressed here

The separate `crowdsecAppsecHTTPTimeoutSeconds` ask at the end of #384 is a sensible one and I have left it out of this PR — it is a config addition rather than a bug fix, and better tracked separately as @shockstricken suggested.
